### PR TITLE
Round3 linting

### DIFF
--- a/Cohort curation scripts/01_CURE_ID_Cohort.sql
+++ b/Cohort curation scripts/01_CURE_ID_Cohort.sql
@@ -113,15 +113,15 @@ SELECT COUNT(DISTINCT person_id) AS "covid_positive_lab_person_count" FROM #firs
 SELECT
     v.person_id,
     v.visit_occurrence_id,
-    visit_start_date,
-    visit_end_date,
+    v.visit_start_date,
+    v.visit_end_date,
     p.First_Pos_Date,
     DATEDIFF(DAY, p.First_Pos_Date, v.visit_start_date) AS "Days_From_First_Pos",
     ABS(DATEDIFF(DAY, p.First_Pos_Date, v.visit_start_date)) AS "Abs_Days_From_First_Pos"
 INTO #inpat_intermed
 FROM visit_occurrence AS v
 INNER JOIN #first_pos AS p ON v.person_id = p.person_id
-WHERE visit_concept_id IN (9201, 262); --Inpatient visit/ED and inpt visit
+WHERE v.visit_concept_id IN (9201, 262); --Inpatient visit/ED and inpt visit
 
 --Intermediate count of Covid-positive patients with inpatient encounters
 SELECT COUNT(DISTINCT person_id) AS "covid_pos_inpatients_count" FROM #inpat_intermed;
@@ -140,8 +140,8 @@ WHERE
 SELECT
     v.person_id,
     v.visit_occurrence_id,
-    visit_start_date,
-    visit_end_date,
+    v.visit_start_date,
+    v.visit_end_date,
     p.First_Pos_Date,
     DATEDIFF(MINUTE, v.visit_start_datetime, v.visit_end_datetime) AS "Length_Of_Stay",
     DATEDIFF(DAY, p.First_Pos_Date, v.visit_start_date) AS "Days_From_First_Pos",
@@ -154,7 +154,7 @@ INTO #inpat
 FROM visit_occurrence AS v
 INNER JOIN #first_pos AS p ON v.person_id = p.person_id
 WHERE
-    visit_concept_id IN (9201, 262) --Inpatient visit/ED and inpt visit
+    v.visit_concept_id IN (9201, 262) --Inpatient visit/ED and inpt visit
     AND v.visit_start_date >= '2020-01-01'
     AND (
         DATEDIFF(DAY, p.First_Pos_Date, v.visit_start_date) > -7
@@ -179,7 +179,7 @@ GROUP BY person_id;
 --Ex: Patient hospitalized separately 3 days before and 3 days after SARS-COV-2 test
 SELECT
     i.person_id,
-    MAX(Before_Or_After) AS "Flag"
+    MAX(i.Before_Or_After) AS "Flag"
 INTO #inpat_first_vis
 FROM #inpat AS i
 INNER JOIN #inpat_closest_vis AS v
@@ -191,8 +191,8 @@ GROUP BY i.person_id;
 --Create flag for longest LOs per person per visit_start_date
 SELECT
     i.person_id,
-    visit_start_date,
-    MAX(Length_Of_Stay) AS "max_los"
+    i.visit_start_date,
+    MAX(i.Length_Of_Stay) AS "max_los"
 INTO #los
 FROM #inpat AS i
 GROUP BY i.person_id, i.visit_start_date;

--- a/Cohort curation scripts/02_CURE_ID_All_Tables.sql
+++ b/Cohort curation scripts/02_CURE_ID_All_Tables.sql
@@ -83,12 +83,12 @@ INNER JOIN [Results].[CURE_ID_Cohort] AS coh
         m.person_id = coh.person_id
         AND m.measurement_date BETWEEN DATEADD(DAY, -1, coh.visit_start_date) AND DATEADD(DAY, 1, coh.visit_end_date)
 INNER JOIN CONCEPT_ANCESTOR
-    ON descendant_concept_id = m.measurement_concept_id
+    ON CONCEPT_ANCESTOR.descendant_concept_id = m.measurement_concept_id
 INNER JOIN [Results].[cure_id_concepts]
-    ON ancestor_concept_id = concept_id
+    ON CONCEPT_ANCESTOR.ancestor_concept_id = [Results].[cure_id_concepts].concept_id
 WHERE
-    domain = 'Measurement'
-    AND (include_descendants = 'TRUE' OR ancestor_concept_id = descendant_concept_id)
+    [Results].[cure_id_concepts].domain = 'Measurement'
+    AND ([Results].[cure_id_concepts]include_descendants = 'TRUE' OR CONCEPT_ANCESTOR.ancestor_concept_id = CONCEPT_ANCESTOR.descendant_concept_id)
 
 --Load drug_exposure table
 SELECT
@@ -171,12 +171,12 @@ INNER JOIN [Results].[CURE_ID_Cohort] AS coh
         o.person_id = coh.person_id
         AND o.observation_date BETWEEN DATEADD(YEAR, -1, coh.visit_start_date) AND DATEADD(YEAR, 1, coh.visit_end_date)
 INNER JOIN CONCEPT_ANCESTOR
-    ON descendant_concept_id = o.observation_concept_id
+    ON CONCEPT_ANCESTOR.descendant_concept_id = o.observation_concept_id
 INNER JOIN [Results].[cure_id_concepts]
-    ON ancestor_concept_id = concept_id
+    ON CONCEPT_ANCESTOR.ancestor_concept_id = [Results].[cure_id_concepts].concept_id
 WHERE
-    domain = 'Observation'
-    AND (include_descendants = 'TRUE' OR ancestor_concept_id = descendant_concept_id)
+    [Results].[cure_id_concepts].domain = 'Observation'
+    AND ([Results].[cure_id_concepts].include_descendants = 'TRUE' OR CONCEPT_ANCESTOR.ancestor_concept_id = CONCEPT_ANCESTOR.descendant_concept_id)
 
 --Load Procedure Occurrence Table
 SELECT
@@ -203,12 +203,12 @@ INNER JOIN [Results].[CURE_ID_Cohort] AS coh
         p.person_id = coh.person_id
         AND p.procedure_date BETWEEN DATEADD(DAY, -1, coh.visit_start_date) AND DATEADD(DAY, 1, coh.visit_end_date)
 INNER JOIN CONCEPT_ANCESTOR
-    ON descendant_concept_id = p.procedure_concept_id
+    ON CONCEPT_ANCESTOR.descendant_concept_id = p.procedure_concept_id
 INNER JOIN [Results].[cure_id_concepts]
-    ON ancestor_concept_id = concept_id
+    ON CONCEPT_ANCESTOR.ancestor_concept_id = [Results].[cure_id_concepts].concept_id
 WHERE
-    domain = 'Procedure'
-    AND (include_descendants = 'TRUE' OR ancestor_concept_id = descendant_concept_id)
+    [Results].[cure_id_concepts].domain = 'Procedure'
+    AND ([Results].[cure_id_concepts].include_descendants = 'TRUE' OR CONCEPT_ANCESTOR.ancestor_concept_id = CONCEPT_ANCESTOR.descendant_concept_id)
 
 --Load Condition Occurrence table
 SELECT
@@ -239,12 +239,12 @@ INNER JOIN [Results].[CURE_ID_Cohort] AS coh
             OR c.condition_end_date IS NULL
         )
 INNER JOIN CONCEPT_ANCESTOR
-    ON descendant_concept_id = c.condition_concept_id
+    ON CONCEPT_ANCESTOR.descendant_concept_id = c.condition_concept_id
 INNER JOIN [Results].[cure_id_concepts]
-    ON ancestor_concept_id = concept_id
+    ON CONCEPT_ANCESTOR.ancestor_concept_id = [Results].[cure_id_concepts].concept_id
 WHERE
-    domain = 'Condition'
-    AND (include_descendants = 'TRUE' OR ancestor_concept_id = descendant_concept_id)
+    [Results].[cure_id_concepts].domain = 'Condition'
+    AND ([Results].[cure_id_concepts].include_descendants = 'TRUE' OR CONCEPT_ANCESTOR.ancestor_concept_id = CONCEPT_ANCESTOR.descendant_concept_id)
 
 --Load Visit Occurrence table
 SELECT DISTINCT
@@ -301,9 +301,9 @@ INNER JOIN [Results].[CURE_ID_Cohort] AS coh
         dev.person_id = coh.person_id
         AND dev.device_exposure_start_date BETWEEN DATEADD(DAY, -1, coh.visit_start_date) AND DATEADD(DAY, 1, coh.visit_end_date)
 INNER JOIN CONCEPT_ANCESTOR
-    ON descendant_concept_id = dev.device_concept_id
+    ON CONCEPT_ANCESTOR.descendant_concept_id = dev.device_concept_id
 INNER JOIN [Results].[cure_id_concepts]
-    ON ancestor_concept_id = concept_id
+    ON CONCEPT_ANCESTOR.ancestor_concept_id = [Results].[cure_id_concepts].concept_id
 WHERE
-    domain = 'Device'
-    AND (include_descendants = 'TRUE' OR ancestor_concept_id = descendant_concept_id)
+    [Results].[cure_id_concepts].domain = 'Device'
+    AND ([Results].[cure_id_concepts].include_descendants = 'TRUE' OR CONCEPT_ANCESTOR.ancestor_concept_id = CONCEPT_ANCESTOR.descendant_concept_id)

--- a/Cohort curation scripts/07_A_condition_profile.sql
+++ b/Cohort curation scripts/07_A_condition_profile.sql
@@ -18,43 +18,40 @@ USE YOUR_DATABASE;
 --Profile condition prevalence in cohort by individual condition concept
 --Condition counts include descendants 
 SELECT
-    concept_name AS condition_name,
-    ancestor_concept_id,
+    CONCEPT.concept_name AS condition_name,
+    CONCEPT_ANCESTOR.ancestor_concept_id,
     COUNT(DISTINCT c.person_id) AS persons_with_condition_or_descendant,
-    100 * COUNT(DISTINCT c.person_id) / (SELECT COUNT(DISTINCT person_id) FROM [Results].[deident_CURE_ID_Person]) AS percent_persons_with_condition
+    100 * COUNT(DISTINCT c.person_id) / (SELECT COUNT(DISTINCT c.person_id) FROM [Results].[deident_CURE_ID_Person]) AS percent_persons_with_condition
 FROM
     [Results].[deident_CURE_ID_Condition_Occurrence] AS c
 INNER JOIN CONCEPT_ANCESTOR
     ON
-        descendant_concept_id = c.condition_concept_id
-        AND ancestor_concept_id IN
+        CONCEPT_ANCESTOR.descendant_concept_id = c.condition_concept_id
+        AND CONCEPT_ANCESTOR.ancestor_concept_id IN
         (SELECT condition_concept_id FROM [Results].[deident_CURE_ID_Condition_Occurrence])
 LEFT JOIN CONCEPT
-    ON concept.concept_id = CONCEPT_ANCESTOR.ancestor_concept_id
-GROUP BY
-    ancestor_concept_id,
-    concept_name
+    ON CONCEPT.concept_id = CONCEPT_ANCESTOR.ancestor_concept_id
+GROUP BY CONCEPT_ANCESTOR.ancestor_concept_id, CONCEPT.concept_name
 ORDER BY persons_with_condition_or_descendant DESC
 
 --Profile condition prevalence in cohort by parent condition concepts
 SELECT
-    concept_name AS condition_name,
-    ancestor_concept_id,
+    [Results].[cure_id_concepts].concept_name AS condition_name,
+    CONCEPT_ANCESTOR.ancestor_concept_id,
     COUNT(DISTINCT c.person_id) AS persons_with_condition,
-    100 * COUNT(DISTINCT c.person_id) / (SELECT COUNT(DISTINCT person_id) FROM [Results].[deident_CURE_ID_Person]) AS percent_persons_with_condition
+    100 * COUNT(DISTINCT c.person_id) / (SELECT COUNT(DISTINCT c.person_id) FROM [Results].[deident_CURE_ID_Person]) AS percent_persons_with_condition
 FROM
     [Results].[deident_CURE_ID_Condition_Occurrence] AS c
-LEFT JOIN
-    CONCEPT_ANCESTOR
-    ON
-        descendant_concept_id = c.condition_concept_id
-
+LEFT JOIN CONCEPT_ANCESTOR
+    ON CONCEPT_ANCESTOR.descendant_concept_id = c.condition_concept_id
 INNER JOIN [Results].[cure_id_concepts]
-    ON ancestor_concept_id = concept_id
+    ON CONCEPT_ANCESTOR.ancestor_concept_id = [Results].[cure_id_concepts].concept_id
 WHERE
-    domain = 'Condition'
-    AND (include_descendants = 'TRUE' OR ancestor_concept_id = descendant_concept_id)
+    [Results].[cure_id_concepts].domain = 'Condition'
+    AND (
+        [Results].[cure_id_concepts].include_descendants = 'TRUE'
+        OR CONCEPT_ANCESTOR.ancestor_concept_id = CONCEPT_ANCESTOR.descendant_concept_id
+    )
 GROUP BY
-    ancestor_concept_id,
-    concept_name
+    CONCEPT_ANCESTOR.ancestor_concept_id, [Results].[cure_id_concepts].concept_name
 ORDER BY persons_with_condition DESC

--- a/Cohort curation scripts/07_C_drug_exposure_profile.sql
+++ b/Cohort curation scripts/07_C_drug_exposure_profile.sql
@@ -23,7 +23,7 @@ LEFT JOIN CONCEPT
     ON CONCEPT.concept_id = [Results].[deident_CURE_ID_drug_exposure].drug_concept_id;
 
 --Roll up drugs into ingredients
-DROP TABLE IF EXISTS #ingredients_of_interest
+DROP TABLE IF EXISTS #ingredients_of_interest;
 SELECT
     dci.concept_id AS drug_concept_id,
     dci.concept_name AS drug_concept_name,
@@ -34,19 +34,19 @@ FROM #drug_concepts_of_interest AS dci
 LEFT JOIN
     CONCEPT_ANCESTOR
     ON
-        descendant_concept_id = dci.concept_id
+        CONCEPT_ANCESTOR.descendant_concept_id = dci.concept_id
 LEFT JOIN CONCEPT
-  ON CONCEPT.concept_id = ancestor_concept_id
+    ON CONCEPT.concept_id = CONCEPT_ANCESTOR.ancestor_concept_id
 WHERE
-    concept_class_id = 'Ingredient'
+    CONCEPT.concept_class_id = 'Ingredient'
 
 --Create table of drug exposures by ingredient
 DROP TABLE IF EXISTS #drug_exposure_by_ingredient
 SELECT
-    ingredient_name,
-    ingredient_concept_id,
+    i.ingredient_name,
+    i.ingredient_concept_id,
     d.drug_concept_id,
-    person_id
+    d.person_id
 INTO #drug_exposure_by_ingredient
 FROM [Results].[deident_CURE_ID_drug_exposure] AS d
 LEFT JOIN #ingredients_of_interest AS i
@@ -117,4 +117,4 @@ GROUP BY
         #ingredient_count_by_person
         ON
             #ingredient_use_by_person.ingredient_concept_id = #ingredient_count_by_person.ingredient_concept_id
-    ORDER BY person_count DESC
+    ORDER BY #ingredient_use_by_person.person_count DESC


### PR DESCRIPTION
- Be consistent with table references - either all or none
- If multiple tables used in query, use table references to avoid ambiguity
- Allow subqueries in FROM or JOIN statements but not both, use Common Table Expressions (CTEs) as alternative
- If using DESC or ASC for any column, all columns should have a designation
- Use a consistent convention for casting CONVERT, CAST or ::
- Use fully qualified joins, e.g. INNER, LEFT, RIGHT, etc.
- ELSE NULL is redundant in a CASE statement, just use ELSE
