### PR TITLE
Added updated concepts and earlier code for measurements and drugs

### DIFF
--- a/Cohort curation scripts/00_CURE_ID_create_concept_table.sql
+++ b/Cohort curation scripts/00_CURE_ID_create_concept_table.sql
@@ -1,6 +1,5 @@
-
-drop table if exists [Results].[cure_id_concepts];
-create table [Results].[cure_id_concepts]
+DROP TABLE IF EXISTS [Results].[cure_id_concepts];
+CREATE TABLE [Results].[cure_id_concepts]
 (
 	concept_id		INTEGER	NOT NULL,
 	concept_code	VARCHAR(50) NULL,
@@ -10,205 +9,313 @@ create table [Results].[cure_id_concepts]
 	is_standard	VARCHAR(50) NULL,
 	include_descendants VARCHAR(50) NULL
 )
-insert into [Results].[cure_id_concepts]
-values
-('321042','410429000','Cardiac arrest','Condition','SNOMED','S','TRUE'),
-('44784217','698247007','Cardiac arrhythmia','Condition','SNOMED','S','TRUE'),
-('319835','42343007','Congestive heart failure','Condition','SNOMED','S','TRUE'),
-('435785','7180009','Meningitis','Condition','SNOMED','S','TRUE'),
-('4329847','22298006','Myocardial infarction','Condition','SNOMED','S','TRUE'),
-('314383','50920009','Myocarditis','Condition','SNOMED','S','TRUE'),
-('4182210','52448006','Dementia','Condition','SNOMED','S','TRUE'),
-('436093','67406007','Disseminated intravascular coagulation','Condition','SNOMED','S','TRUE'),
-('441589','56819008','Endocarditis','Condition','SNOMED','S','TRUE'),
-('192671','74474003','Gastrointestinal hemorrhage','Condition','SNOMED','S','TRUE'),
-('317009','195967001','Asthma','Condition','SNOMED','S','TRUE'),
-('4028244','128292002','Chronic disease of cardiovascular system','Condition','SNOMED','S','TRUE'),
-('4063381','17097001','Chronic disease of respiratory system','Condition','SNOMED','S','TRUE'),
-('255573','13645005','Chronic obstructive lung disease','Condition','SNOMED','S','TRUE'),
-('201820','73211009','Diabetes mellitus','Condition','SNOMED','S','TRUE'),
-('439727','86406008','Human immunodeficiency virus infection','Condition','SNOMED','S','TRUE'),
-('316866','38341003','Hypertensive disorder','Condition','SNOMED','S','TRUE'),
-('438112','55342001','Neoplastic disease','Condition','SNOMED','S','TRUE'),
-('4299535','77386006','Pregnant','Condition','SNOMED','S','TRUE'),
-('40401938','205614001','(Downs syndrome - trisomy 21) or (mongolism) or (trisomy 21) or (trisomy 22)','Condition','SNOMED','N','TRUE'),
-('43531681','651000119108','Acute deep vein thrombosis of lower limb','Condition','SNOMED','S','TRUE'),
-('197320','14669001','Acute renal failure syndrome','Condition','SNOMED','S','TRUE'),
-('4195694','67782005','Acute respiratory distress syndrome','Condition','SNOMED','S','TRUE'),
-('439776','35919005','Autism spectrum disorder','Condition','SNOMED','S','TRUE'),
-('132736','5758002','Bacteremia','Condition','SNOMED','S','TRUE'),
-('257315','53084003','Bacterial pneumonia','Condition','SNOMED','S','TRUE'),
-('254061','60046008','Pleural effusion','Condition','SNOMED','S','TRUE'),
-('253796','36118008','Pneumothorax','Condition','SNOMED','S','TRUE'),
-('440417','59282003','Pulmonary embolism','Condition','SNOMED','S','TRUE'),
-('377091','91175000','Seizure','Condition','SNOMED','S','TRUE'),
-('43530623','1131000119105','Sequela of cerebrovascular accident','Condition','SNOMED','S','TRUE'),
-('4281232','66071002','Type B viral hepatitis','Condition','SNOMED','S','TRUE'),
-('197494','50711007','Viral hepatitis C','Condition','SNOMED','S','TRUE'),
-('261326','75570004','Viral pneumonia','Condition','SNOMED','S','TRUE'),
-('381591','62914000','Cerebrovascular disease','Condition','SNOMED','S','TRUE'),
-('4063381','17097001','Chronic disease of respiratory system','Condition','SNOMED','S','TRUE'),
-('4212540','328383001','Chronic liver disease','Condition','SNOMED','S','TRUE'),
-('4064161','19943007','Cirrhosis of liver','Condition','SNOMED','S','TRUE'),
-('442793','74627003','Complication due to diabetes mellitus','Condition','SNOMED','S','TRUE'),
-('4182210','52448006','Dementia','Condition','SNOMED','S','TRUE'),
-('201820','73211009','Diabetes mellitus','Condition','SNOMED','S','TRUE'),
-('443767','25093002','Disorder of eye due to diabetes mellitus','Condition','SNOMED','S','TRUE'),
-('24966','28670008','Esophageal varices','Condition','SNOMED','S','TRUE'),
-('4247120','40845000','Gastrointestinal ulcer','Condition','SNOMED','S','TRUE'),
-('316139','84114007','Heart failure','Condition','SNOMED','S','TRUE'),
-('374022','50582007','Hemiplegia','Condition','SNOMED','S','TRUE'),
-('4029488','13920009','Hepatic encephalopathy','Condition','SNOMED','S','TRUE'),
-('4245975','59927004','Hepatic failure','Condition','SNOMED','S','TRUE'),
-('439727','86406008','Human immunodeficiency virus infection','Condition','SNOMED','S','TRUE'),
-('434056','195239002','Late effects of cerebrovascular disease','Condition','SNOMED','S','TRUE'),
-('443392','363346000','Malignant neoplastic disease','Condition','SNOMED','S','TRUE'),
-('4329847','22298006','Myocardial infarction','Condition','SNOMED','S','TRUE'),
-('192606','60389000','Paraplegia','Condition','SNOMED','S','TRUE'),
-('321052','400047006','Peripheral vascular disease','Condition','SNOMED','S','TRUE'),
-('255348','65323003','Polymyalgia rheumatica','Condition','SNOMED','S','TRUE'),
-('80800','31384009','Polymyositis','Condition','SNOMED','S','TRUE'),
-('192680','34742003','Portal hypertension','Condition','SNOMED','S','TRUE'),
-('4030518','236423003','Renal impairment','Condition','SNOMED','S','TRUE'),
-('80809','69896004','Rheumatoid arthritis','Condition','SNOMED','S','TRUE'),
-('256197','398726004','Rheumatoid lung disease','Condition','SNOMED','S','TRUE'),
-('432851','128462008','Secondary malignant neoplastic disease','Condition','SNOMED','S','TRUE'),
-('257628','55464009','Systemic lupus erythematosus','Condition','SNOMED','S','TRUE'),
-('134442','89155008','Systemic sclerosis','Condition','SNOMED','S','TRUE'),
-('4138487','426294006','Face tent oxygen delivery device','Device','SNOMED','S','FALSE'),
-('4281167','36965003','Hemodialysis machine','Device','SNOMED','S','TRUE'),
-('4222966','336602003','Oxygen mask','Device','SNOMED','S','TRUE'),
-('4224038','336623009','Oxygen nasal cannula','Device','SNOMED','S','TRUE'),
-('45768197','706172005','Ventilator','Device','SNOMED','S','TRUE'),
-('4164918','45633005','Peritoneal dialyzer','Device','SNOMED','S','FALSE'),
-('40493026','449071006','Mechanical ventilator','Device','SNOMED','S','TRUE'),
-('3473837','426160001','Oxygen ventilator','Device','Nebraska Lexicon','N','TRUE'),
-('1321341','7512','norepinephrine','Drug','RxNorm','S','FALSE'),
-('1337720','3616','dobutamine','Drug','RxNorm','S','FALSE'),
-('1343916','3992','epinephrine','Drug','RxNorm','S','FALSE'),
-('21600280','C01CA','Adrenergic and dopaminergic agents','Drug','ATC','C','TRUE'),
-('1135766','8163','phenylephrine','Drug','RxNorm','S','FALSE'),
-('1507835','11149','vasopressin (USP)','Drug','RxNorm','S','FALSE'),
-('38003563','Hispanic','Hispanic or Latino','Ethnicity','Ethnicity','S','FALSE'),
-('38003564','Not Hispanic','Not Hispanic or Latino','Ethnicity','Ethnicity','S','FALSE'),
-('8507','M','MALE','Gender','Gender','S','FALSE'),
-('8532','F','FEMALE','Gender','Gender','S','FALSE'),
-('8570','A','AMBIGUOUS','Gender','Gender','N','FALSE'),
-('8521','O','OTHER','Gender','Gender','N','FALSE'),
-('8551','U','UNKNOWN','Gender','Gender','N','FALSE'),
-('40773382','LP43012-1','Coccidioides immitis IgG | Bld-Ser-Plas','Measurement','LOINC','N','FALSE'),
-('40796545','LP43013-9','Coccidioides immitis IgM | Bld-Ser-Plas','Measurement','LOINC','N','FALSE'),
-('36207253','LP256485-6','Histoplasma capsulatum | Urine','Measurement','LOINC','N','FALSE'),
-('37069484','LP376381-2','Histoplasma capsulatum Ag | Serum | Microbiology','Measurement','LOINC','C','FALSE'),
-('37025945','LP377195-5','Human coronavirus RNA | XXX | Microbiology','Measurement','LOINC','C','FALSE'),
-('37068812','LP378241-6','Human metapneumovirus RNA | XXX | Microbiology','Measurement','LOINC','C','FALSE'),
-('37050664','LP378502-1','Influenza virus A RNA | XXX | Microbiology','Measurement','LOINC','C','FALSE'),
-('37024394','LP378559-1','Influenza virus B RNA | XXX | Microbiology','Measurement','LOINC','C','FALSE'),
-('3005629','3151-8','Inhaled oxygen flow rate','Measurement','LOINC','S','FALSE'),
-('3022217','6301-6','INR in Platelet poor plasma by Coagulation assay','Measurement','LOINC','S','FALSE'),
-('4353936','250774007','Inspired oxygen concentration','Measurement','SNOMED','S','FALSE'),
-('703443','1300671000000104','COVID-19 severity scale','Measurement','SNOMED','S','FALSE'),
-('3002385','30385-9','Erythrocyte distribution width [Ratio]','Measurement','LOINC','S','FALSE'),
-('36205488','LP260072-6','Galactomannan | Bronchoalveolar lavage','Measurement','LOINC','N','FALSE'),
-('37033649','LP376244-2','Galactomannan Ag | Serum or Plasma | Microbiology','Measurement','LOINC','C','FALSE'),
-('3027018','8867-4','Heart rate','Measurement','LOINC','S','FALSE'),
-('3000963','718-7','Hemoglobin [Mass/volume] in Blood','Measurement','LOINC','S','FALSE'),
-('37024723','LP380002-8','Herpes virus 6 DNA panel | XXX | Microbiology Panels','Measurement','LOINC','C','FALSE'),
-('40652525','LG5272-2','Alanine aminotransferase|CCnc|Pt|ANYBldSerPl','Measurement','LOINC','C','TRUE'),
-('37041593','LP393946-1','aPTT | Platelet poor plasma | Coagulation','Measurement','LOINC','C','TRUE'),
-('37042222','LP392736-7','Basophils | Blood | Hematology and Cell counts','Measurement','LOINC','C','TRUE'),
-('40652709','LG6199-6','Bilirubin|MCnc|Pt|ANYBldSerPl','Measurement','LOINC','C','TRUE'),
-('3020891','8310-5','Body temperature','Measurement','LOINC','S','TRUE'),
-('3007220','2157-6','Creatine kinase [Enzymatic activity/volume] in Serum or Plasma','Measurement','LOINC','S','TRUE'),
-('3045262','45066-8','Creatinine and Glomerular filtration rate.predicted panel - Serum, Plasma or Blood','Measurement','LOINC','S','TRUE'),
-('40652870','LG6657-3','Creatinine|MCnc|Pt|ANYBldSerPl','Measurement','LOINC','C','TRUE'),
-('4141684','427081008','Delivered oxygen flow rate','Measurement','SNOMED','S','TRUE'),
-('3023361','7799-0','Deprecated Fibrin D-dimer [Units/volume] in Platelet poor plasma','Measurement','LOINC','N','TRUE'),
-('3012888','8462-4','Diastolic blood pressure','Measurement','LOINC','S','TRUE'),
-('40653994','LG32849-8','Eosinophils|NCnc|Pt|Bld','Measurement','LOINC','C','TRUE'),
-('37041261','LP393348-0','Erythrocyte distribution width | Red Blood Cells | Hematology and Cell counts','Measurement','LOINC','C','TRUE'),
-('37070654','LP385083-3','Ferritin | Serum or Plasma | Chemistry - non-challenge','Measurement','LOINC','C','TRUE'),
-('37051715','LP394015-4','Fibrin D-dimer FEU | Platelet poor plasma | Coagulation','Measurement','LOINC','C','TRUE'),
-('37032427','LP394019-6','Fibrinogen | Platelet poor plasma | Coagulation','Measurement','LOINC','C','TRUE'),
-('40771922','69405-9','Glomerular filtration rate/1.73 sq M.predicted [Volume Rate/Area] in Serum, Plasma or Blood','Measurement','LOINC','S','TRUE'),
-('40653085','LG7967-5','Glucose|MCnc|Pt|ANYBldSerPl','Measurement','LOINC','C','TRUE'),
-('37070108','LP392479-4','Hematocrit | Blood | Hematology and Cell counts','Measurement','LOINC','C','TRUE'),
-('3023091','26881-3','Interleukin 6 [Mass/volume] in Serum or Plasma','Measurement','LOINC','S','TRUE'),
-('3034022','42929-0','Lactate dehydrogenase panel - Serum or Plasma','Measurement','LOINC','S','TRUE'),
-('40653238','LG6039-4','Lactate|SCnc|Pt|ANYBldSerPl','Measurement','LOINC','C','TRUE'),
-('37043992','LP392599-9','Leukocytes | Blood | Hematology and Cell counts','Measurement','LOINC','C','TRUE'),
-('40654045','LG32863-9','Lymphocytes|NCnc|Pt|Bld','Measurement','LOINC','C','TRUE'),
-('40654069','LG32885-2','Monocytes|NCnc|Pt|Bld','Measurement','LOINC','C','TRUE'),
-('40654088','LG32886-0','Neutrophils|NCnc|Pt|Bld','Measurement','LOINC','C','TRUE'),
-('40653596','LG10990-6','Potassium|SCnc|Pt|ANYBldSerPl','Measurement','LOINC','C','TRUE'),
-('40653762','LG11363-5','Sodium|SCnc|Pt|ANYBldSerPl','Measurement','LOINC','C','TRUE'),
-('37063873','LP385942-0','Troponin I.cardiac | Serum or Plasma | Chemistry - non-challenge','Measurement','LOINC','C','TRUE'),
-('40653900','LG1314-6','Urea nitrogen|MCnc|Pt|ANYBldSerPl','Measurement','LOINC','C','TRUE'),
-('37075814','LP379721-6','1,3 beta glucan | Serum | Microbiology','Measurement','LOINC','C','FALSE'),
-('37050195','LP377083-3','Adenovirus DNA | XXX | Microbiology','Measurement','LOINC','C','FALSE'),
-('37049794','LP382722-9','Alkaline phosphatase | Serum or Plasma | Chemistry - non-challenge','Measurement','LOINC','C','FALSE'),
-('3018677','14979-9','aPTT in Platelet poor plasma by Coagulation assay','Measurement','LOINC','S','FALSE'),
-('3013721','1920-8','Aspartate aminotransferase [Enzymatic activity/volume] in Serum or Plasma','Measurement','LOINC','S','FALSE'),
-('3022893','1916-6','Aspartate aminotransferase/Alanine aminotransferase [Enzymatic activity ratio] in Serum or Plasma','Measurement','LOINC','S','FALSE'),
-('3006315','26444-0','Basophils [#/volume] in Blood','Measurement','LOINC','S','FALSE'),
-('3045524','34543-9','Bilirubin direct and total panel [Mass/volume] - Serum or Plasma','Measurement','LOINC','S','FALSE'),
-('3036277','8302-2','Body height','Measurement','LOINC','S','FALSE'),
-('3038553','39156-5','Body mass index (BMI) [Ratio]','Measurement','LOINC','S','FALSE'),
-('3020460','1988-5','C reactive protein [Mass/volume] in Serum or Plasma','Measurement','LOINC','S','FALSE'),
-('3027801','2703-7','Oxygen [Partial pressure] in Arterial blood','Measurement','LOINC','S','FALSE'),
-('3016502','2708-6','Oxygen saturation in Arterial blood','Measurement','LOINC','S','FALSE'),
-('40762499','59408-5','Oxygen saturation in Arterial blood by Pulse oximetry','Measurement','LOINC','S','FALSE'),
-('3026238','19996-8','Oxygen/Inspired gas Respiratory system --on ventilator','Measurement','LOINC','S','FALSE'),
-('3025634','29908-1','Parainfluenza virus 1 RNA [Presence] in Specimen by NAA with probe detection','Measurement','LOINC','S','FALSE'),
-('3007461','26515-7','Platelets [#/volume] in Blood','Measurement','LOINC','S','FALSE'),
-('3024929','777-3','Platelets [#/volume] in Blood by Automated count','Measurement','LOINC','S','FALSE'),
-('3010834','778-1','Platelets [#/volume] in Blood by Manual count','Measurement','LOINC','S','FALSE'),
-('3046279','33959-8','Procalcitonin [Mass/volume] in Serum or Plasma','Measurement','LOINC','S','FALSE'),
-('3034426','5902-2','Prothrombin time (PT)','Measurement','LOINC','S','FALSE'),
-('3024171','9279-1','Respiratory rate','Measurement','LOINC','S','FALSE'),
-('37065137','LP378960-1','Respiratory syncytial virus RNA | XXX | Microbiology','Measurement','LOINC','C','FALSE'),
-('37055446','LP378971-8','Rhinovirus RNA | XXX | Microbiology','Measurement','LOINC','C','FALSE'),
-('3004249','8480-6','Systolic blood pressure','Measurement','LOINC','S','FALSE'),
-('1004141','LP415675-0','Body weight | Patient | General body weight','Measurement','LOINC','C','TRUE'),
-('45889365','1012740','Dialysis Services and Procedures','Observation','CPT4','C','TRUE'),
-('46235215','76691-5','Gender identity','Observation','LOINC','S','TRUE'),
-('4039922','229306004','Positive pressure therapy','Observation','SNOMED','S','TRUE'),
-('3046853','32624-9','Race','Observation','LOINC','S','TRUE'),
-('36033639','97155-6','SARS coronavirus 2 (COVID-19) immunization status','Observation','LOINC','S','TRUE'),
-('4298794','77176002','Smoker','Observation','SNOMED','S','TRUE'),
-('4275495','365981007','Tobacco smoking behavior - finding','Observation','SNOMED','S','TRUE'),
-('4203942','52870002','Admitting diagnosis','Observation','SNOMED','S','FALSE'),
-('4201025','315041000','High concentration oxygen therapy','Procedure','SNOMED','S','FALSE'),
-('4119964','304577004','Humidified oxygen therapy','Procedure','SNOMED','S','FALSE'),
-('4216695','71786000','Intranasal oxygen therapy','Procedure','SNOMED','S','FALSE'),
-('40486624','447837008','Noninvasive positive pressure ventilation','Procedure','SNOMED','S','FALSE'),
-('4177224','428311008','Noninvasive ventilation','Procedure','SNOMED','S','FALSE'),
-('37018292','714749008','Continuous renal replacement therapy','Procedure','SNOMED','S','FALSE'),
-('3171077','28690001000004105','Emergent dialysis','Procedure','Nebraska Lexicon','S','FALSE'),
-('3655950','870533002','Heated and humidified high flow oxygen therapy','Procedure','SNOMED','S','FALSE'),
-('4120120','302497006','Hemodialysis','Procedure','SNOMED','S','FALSE'),
-('2213573','90937','Hemodialysis procedure requiring repeated evaluation(s) with or without substantial revision of dialysis prescription','Procedure','CPT4','S','FALSE'),
-('2213572','90935','Hemodialysis procedure with single evaluation by a physician or other qualified health care professional','Procedure','CPT4','S','FALSE'),
-('2213576','90945','Dialysis procedure other than hemodialysis (eg, peritoneal dialysis, hemofiltration, or other continuous renal replacement therapies), with single evaluation by a physician or other qualified health care professional','Procedure','CPT4','S','TRUE'),
-('4052536','233573008','Extracorporeal membrane oxygenation','Procedure','SNOMED','S','TRUE'),
-('46257585','1022227','Extracorporeal membrane oxygenation (ECMO)/extracorporeal life support (ECLS) provided by physician','Procedure','CPT4','C','TRUE'),
-('45889034','1012752','Hemodialysis Procedures','Procedure','CPT4','C','TRUE'),
-('4237460','408853006','Intermittent positive pressure ventilation via endotracheal tube','Procedure','SNOMED','S','TRUE'),
-('3655896','870386000','Vasopressor therapy','Procedure','SNOMED','S','TRUE'),
-('4230167','40617009','Artificial respiration','Procedure','SNOMED','S','FALSE'),
-('4162736','371908008','Oxygen administration by mask','Procedure','SNOMED','S','FALSE'),
-('4155151','371907003','Oxygen administration by nasal cannula','Procedure','SNOMED','S','FALSE'),
-('44790731','240051000000102','Oxygen administration by non rebreather mask','Procedure','SNOMED','S','FALSE'),
-('4082249','182714002','Oxygenator therapy','Procedure','SNOMED','S','FALSE'),
-('4324124','71192002','Peritoneal dialysis','Procedure','SNOMED','S','FALSE'),
-('4146536','265764009','Renal dialysis','Procedure','SNOMED','S','FALSE'),
-('8557','4','Native Hawaiian or Other Pacific Islander','Race','Race','S','FALSE'),
-('8657','1','American Indian or Alaska Native','Race','Race','S','FALSE'),
-('8515','2','Asian','Race','Race','S','FALSE'),
-('8516','3','Black or African American','Race','Race','S','FALSE'),
-('8527','5','White','Race','Race','S','FALSE'),
-('2004208004','NA','Other oxygen device','Device','Custom','C','FALSE'),
-('2004208005','NA','Room air (in the context of a device)','Device','Custom','C','FALSE'),
-('2004208006','NA','CPAP (continuous positive airway pressure)','Device','Custom','C','FALSE'),
-('2004208007','NA','BiPAP (bilevel positive airway pressure)','Device','Custom','C','FALSE'),
-('2004208008','NA','NIPPV (non-invasive positive pressure ventilation or nasal intermittent positive pressure ventilation)','Device','Custom','C','FALSE');
+;
+
+INSERT INTO [Results].[cure_id_concepts]
+VALUES
+   (2000000999, NULL, NULL, NULL, NULL, NULL, 'FALSE'),  --Advance branch
+   (24966, '28670008', 'Esophageal varices', 'Condition', 'SNOMED', 'S', 'TRUE'),  --Charlson
+   (80800, '31384009', 'Polymyositis', 'Condition', 'SNOMED', 'S', 'TRUE'),  --Charlson
+   (80809, '69896004', 'Rheumatoid arthritis', 'Condition', 'SNOMED', 'S', 'TRUE'),  --Charlson
+   (134442, '89155008', 'Systemic sclerosis', 'Condition', 'SNOMED', 'S', 'TRUE'),  --Charlson
+   (192606, '60389000', 'Paraplegia', 'Condition', 'SNOMED', 'S', 'TRUE'),  --Charlson
+   (192680, '34742003', 'Portal hypertension', 'Condition', 'SNOMED', 'S', 'TRUE'),  --Charlson
+   (201820, '73211009', 'Diabetes mellitus', 'Condition', 'SNOMED', 'S', 'TRUE'),  --Charlson
+   (255348, '65323003', 'Polymyalgia rheumatica', 'Condition', 'SNOMED', 'S', 'TRUE'),  --Charlson
+   (256197, '398726004', 'Rheumatoid lung disease', 'Condition', 'SNOMED', 'S', 'TRUE'),  --Charlson
+   (257628, '55464009', 'Systemic lupus erythematosus', 'Condition', 'SNOMED', 'S', 'TRUE'),  --Charlson
+   (316139, '84114007', 'Heart failure', 'Condition', 'SNOMED', 'S', 'TRUE'),  --Charlson
+   (321052, '400047006', 'Peripheral vascular disease', 'Condition', 'SNOMED', 'S', 'TRUE'),  --Charlson
+   (374022, '50582007', 'Hemiplegia', 'Condition', 'SNOMED', 'S', 'TRUE'),  --Charlson
+   (381591, '62914000', 'Cerebrovascular disease', 'Condition', 'SNOMED', 'S', 'TRUE'),  --Charlson
+   (432851, '128462008', 'Secondary malignant neoplastic disease', 'Condition', 'SNOMED', 'S', 'TRUE'),  --Charlson
+   (434056, '195239002', 'Late effects of cerebrovascular disease', 'Condition', 'SNOMED', 'S', 'TRUE'),  --Charlson
+   (439727, '86406008', 'Human immunodeficiency virus infection', 'Condition', 'SNOMED', 'S', 'TRUE'),  --Charlson
+   (442793, '74627003', 'Complication due to diabetes mellitus', 'Condition', 'SNOMED', 'S', 'TRUE'),  --Charlson
+   (443392, '363346000', 'Malignant neoplastic disease', 'Condition', 'SNOMED', 'S', 'TRUE'),  --Charlson
+   (443767, '25093002', 'Disorder of eye due to diabetes mellitus', 'Condition', 'SNOMED', 'S', 'TRUE'),  --Charlson
+   (4029488, '13920009', 'Hepatic encephalopathy', 'Condition', 'SNOMED', 'S', 'TRUE'),  --Charlson
+   (4030518, '236423003', 'Renal impairment', 'Condition', 'SNOMED', 'S', 'TRUE'),  --Charlson
+   (4063381, '17097001', 'Chronic disease of respiratory system', 'Condition', 'SNOMED', 'S', 'TRUE'),  --Charlson
+   (4064161, '19943007', 'Cirrhosis of liver', 'Condition', 'SNOMED', 'S', 'TRUE'),  --Charlson
+   (4182210, '52448006', 'Dementia', 'Condition', 'SNOMED', 'S', 'TRUE'),  --Charlson
+   (4212540, '328383001', 'Chronic liver disease', 'Condition', 'SNOMED', 'S', 'TRUE'),  --Charlson
+   (4245975, '59927004', 'Hepatic failure', 'Condition', 'SNOMED', 'S', 'TRUE'),  --Charlson
+   (4247120, '40845000', 'Gastrointestinal ulcer', 'Condition', 'SNOMED', 'S', 'TRUE'),  --Charlson
+   (4329847, '22298006', 'Myocardial infarction', 'Condition', 'SNOMED', 'S', 'TRUE'),  --Charlson
+   (4152194, '271649006', 'Systolic blood pressure', 'Measurement', 'SNOMED', 'S', 'FALSE'),  --Site
+   (4154790, '271650006', 'Diastolic blood pressure', 'Measurement', 'SNOMED', 'S', 'FALSE'),  --Site
+   (436677, '17226007', 'Adjustment disorder', 'Condition', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (437449, '397940009', 'Victim of child abuse', 'Condition', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (439664, '160822004', 'Relationship problems', 'Condition', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4019836, '105412007', 'Social exclusion', 'Condition', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4019971, '105515007', 'Discord in school', 'Condition', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4022078, '105520007', 'Discord with counselor', 'Condition', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4022639, '105413002', 'Acculturation difficulty', 'Condition', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4100089, '192119003', 'Sibling jealousy', 'Condition', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4107655, '284465006', 'Finding relating to psychosocial functioning', 'Condition', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4204229, '54038000', 'Insecurity', 'Condition', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4217086, '417427001', 'At risk of discriminatory abuse', 'Condition', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4275902, '64313000', 'Alteration in family processes', 'Condition', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4279142, '65367001', 'Victim status', 'Condition', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (37207707, '82531000000100', 'At risk of homelessness', 'Condition', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (43020462, '287991000119107', 'Discord with neighbors, lodgers and landlord', 'Condition', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (43020468, '288171000119109', 'Child in welfare custody', 'Condition', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (43020488, '288561000119106', 'Problem related to release from prison', 'Condition', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (43020489, '288571000119100', 'Psychosocial problems related to multiparity', 'Condition', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (43021845, '151901000119101', 'Psychosocial problems related to unwanted pregnancy', 'Condition', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (1340204, 'OMOP5165859', 'History of event', 'Observation', 'OMOP Extension', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (439395, '371775004', 'Emotional abuse of child', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (762059, '288431000119102', 'Inadequate parental supervision and control', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (765265, '15929301000119104', 'Problem related to living in residential institution', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4009858, '102425009', 'Exposure to polluted air, occupational', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4010022, '102610002', 'Inadequate food diet', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4010331, '102442003', 'Exposure to toxic agricultural agents, occupational', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4015401, '11403006', 'Financially poor', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4022050, '105419003', 'Academic underachievement', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4022065, '105483008', 'Overprotective parent', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4022070, '105497000', 'Threat of dismissal', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4022652, '105477005', 'Failed exams', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4022658, '105514006', 'Discord in the workplace', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4022661, '105531004', 'Housing problem', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4023168, '105529008', 'Lives alone', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4031491, '14345008', 'Parent/child conflict', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4052625, '160932005', 'Financial problem', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4059628, '160881008', 'Institutionalized childhood', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4059637, '160909006', 'Work environment deleterious', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4059786, '161138004', 'Literacy problems', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4076209, '224229008', 'Sleeping out', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4094126, '248539004', 'Family problems', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4105261, '281575007', 'Family social history', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4139934, '32911000', 'Homeless', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4154624, '271437004', 'Problem situation relating to social and personal history', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4166675, '45361006', 'Imprisonment', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4171584, '276068009', 'Changed job', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4175353, '425022003', 'Inadequate social support', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4175370, '276072008', 'Sexual problems at work', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4177669, '49588008', 'Military services member', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4188165, '414418009', 'Housed', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4251171, '73438004', 'Unemployed', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4261613, '4506002', 'Educational problem', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4273155, '365510008', 'Temporary shelter arrangements - finding', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4296024, '76799001', 'Family disruption due to divorce', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4301229, '78427001', 'Occupational noise exposure', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4310138, '424860001', 'Low income', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4311456, '424466003', 'Water supply insufficient', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4326265, '75148009', 'Employment problem', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (4329840, '22268004', 'Legal problem', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (35622979, '765226004', 'Occupational exposure to extreme temperature', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (36712857, '134561000119109', 'Family disruption due to death of family member', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (37108964, '15936461000119100', 'Stressful work schedule', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (37116643, '733423003', 'Food insecurity', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (37395583, '288001000119103', 'Family member absent due to military deployment', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (42535209, '16090451000119101', 'Occupational exposure to radiation', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (42536905, '735932007', 'Occupational exposure to vibration', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (42537800, '737376008', 'Uncongenial work environment', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (42539211, '16090691000119109', 'Occupational exposure to dust', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (43020416, '105661000119103', 'Problem with aged spouse or partner', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (43020469, '288231000119101', 'Cares for dependent relative at home', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (43020484, '288501000119105', 'Parent child estrangement', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (43020486, '288541000119107', 'Problem related to upbringing', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (43020487, '288551000119109', 'Problem in relationship with in-laws', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (43021798, '473447008', 'Exerting inappropriate parental pressure', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (43021867, '288531000119103', 'Problem related to social environment', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (44782749, '134571000119103', 'Family disruption due to extended absence of family member', 'Observation', 'SNOMED', 'S', 'FALSE'),  --Z code mapped to SNOMED
+   (201820, '73211009', 'Diabetes mellitus', 'Condition', 'SNOMED', 'S', 'TRUE'),  --from extraction script
+   (255573, '13645005', 'Chronic obstructive lung disease', 'Condition', 'SNOMED', 'S', 'TRUE'),  --from extraction script
+   (316866, '38341003', 'Hypertensive disorder', 'Condition', 'SNOMED', 'S', 'TRUE'),  --from extraction script
+   (317009, '195967001', 'Asthma', 'Condition', 'SNOMED', 'S', 'TRUE'),  --from extraction script
+   (438112, '55342001', 'Neoplastic disease', 'Condition', 'SNOMED', 'S', 'TRUE'),  --from extraction script
+   (439727, '86406008', 'Human immunodeficiency virus infection', 'Condition', 'SNOMED', 'S', 'TRUE'),  --from extraction script
+   (4028244, '128292002', 'Chronic disease of cardiovascular system', 'Condition', 'SNOMED', 'S', 'TRUE'),  --from extraction script
+   (4063381, '17097001', 'Chronic disease of respiratory system', 'Condition', 'SNOMED', 'S', 'TRUE'),  --from extraction script
+   (4299535, '77386006', 'Pregnant', 'Condition', 'SNOMED', 'S', 'TRUE'),  --from extraction script
+   (2004208004, NULL, 'Other oxygen device', 'Device', 'Custom', 'C', 'FALSE'),  --from extraction script
+   (2004208005, NULL, 'Room air (in the context of a device)', 'Device', 'Custom', 'C', 'FALSE'),  --from extraction script
+   (2004208006, NULL, 'CPAP (continuous positive airway pressure)', 'Device', 'Custom', 'C', 'FALSE'),  --from extraction script
+   (2004208007, NULL, 'BiPAP (bilevel positive airway pressure)', 'Device', 'Custom', 'C', 'FALSE'),  --from extraction script
+   (2004208008, NULL, 'NIPPV (non-invasive positive pressure ventilation or nasal intermittent positive pressure ventilation)', 'Device', 'Custom', 'C', 'FALSE'),  --from extraction script
+   (4138487, '426294006', 'Face tent oxygen delivery device', 'Device', 'SNOMED', 'S', 'FALSE'),  --from extraction script
+   (4164918, '45633005', 'Peritoneal dialyzer', 'Device', 'SNOMED', 'S', 'FALSE'),  --from extraction script
+   (4222966, '336602003', 'Oxygen mask', 'Device', 'SNOMED', 'S', 'TRUE'),  --from extraction script
+   (4224038, '336623009', 'Oxygen nasal cannula', 'Device', 'SNOMED', 'S', 'TRUE'),  --from extraction script
+   (4281167, '36965003', 'Hemodialysis machine', 'Device', 'SNOMED', 'S', 'TRUE'),  --from extraction script
+   (40493026, '449071006', 'Mechanical ventilator', 'Device', 'SNOMED', 'S', 'TRUE'),  --from extraction script
+   (45768197, '706172005', 'Ventilator', 'Device', 'SNOMED', 'S', 'TRUE'),  --from extraction script
+   (21600280, 'C01CA', 'Adrenergic and dopaminergic agents', 'Drug', 'ATC', 'C', 'TRUE'),  --from extraction script
+   (1135766, '8163', 'phenylephrine', 'Drug', 'RxNorm', 'S', 'FALSE'),  --from extraction script
+   (1321341, '7512', 'norepinephrine', 'Drug', 'RxNorm', 'S', 'FALSE'),  --from extraction script
+   (1337720, '3616', 'dobutamine', 'Drug', 'RxNorm', 'S', 'FALSE'),  --from extraction script
+   (1343916, '3992', 'epinephrine', 'Drug', 'RxNorm', 'S', 'FALSE'),  --from extraction script
+   (1507835, '11149', 'vasopressin (USP)', 'Drug', 'RxNorm', 'S', 'FALSE'),  --from extraction script
+   (38003563, 'Hispanic', 'Hispanic or Latino', 'Ethnicity', 'Ethnicity', 'S', 'FALSE'),  --from extraction script
+   (38003564, 'Not Hispanic', 'Not Hispanic or Latino', 'Ethnicity', 'Ethnicity', 'S', 'FALSE'),  --from extraction script
+   (8507, 'M', 'MALE', 'Gender', 'Gender', 'S', 'FALSE'),  --from extraction script
+   (8521, 'O', 'OTHER', 'Gender', 'Gender', 'N', 'FALSE'),  --from extraction script
+   (8532, 'F', 'FEMALE', 'Gender', 'Gender', 'S', 'FALSE'),  --from extraction script
+   (8551, 'U', 'UNKNOWN', 'Gender', 'Gender', 'N', 'FALSE'),  --from extraction script
+   (8570, 'A', 'AMBIGUOUS', 'Gender', 'Gender', 'N', 'FALSE'),  --from extraction script
+   (3000963, '718-7', 'Hemoglobin [Mass/volume] in Blood', 'Measurement', 'LOINC', 'S', 'FALSE'),  --from extraction script
+   (3002385, '30385-9', 'Erythrocyte distribution width [Ratio]', 'Measurement', 'LOINC', 'S', 'FALSE'),  --from extraction script
+   (3004249, '8480-6', 'Systolic blood pressure', 'Measurement', 'LOINC', 'S', 'FALSE'),  --from extraction script
+   (3005629, '3151-8', 'Inhaled oxygen flow rate', 'Measurement', 'LOINC', 'S', 'FALSE'),  --from extraction script
+   (3006315, '26444-0', 'Basophils [#/volume] in Blood', 'Measurement', 'LOINC', 'S', 'FALSE'),  --from extraction script
+   (3007220, '2157-6', 'Creatine kinase [Enzymatic activity/volume] in Serum or Plasma', 'Measurement', 'LOINC', 'S', 'TRUE'),  --from extraction script
+   (3007461, '26515-7', 'Platelets [#/volume] in Blood', 'Measurement', 'LOINC', 'S', 'FALSE'),  --from extraction script
+   (3010834, '778-1', 'Platelets [#/volume] in Blood by Manual count', 'Measurement', 'LOINC', 'S', 'FALSE'),  --from extraction script
+   (3012888, '8462-4', 'Diastolic blood pressure', 'Measurement', 'LOINC', 'S', 'TRUE'),  --from extraction script
+   (3013721, '1920-8', 'Aspartate aminotransferase [Enzymatic activity/volume] in Serum or Plasma', 'Measurement', 'LOINC', 'S', 'FALSE'),  --from extraction script
+   (3016502, '2708-6', 'Oxygen saturation in Arterial blood', 'Measurement', 'LOINC', 'S', 'FALSE'),  --from extraction script
+   (3018677, '14979-9', 'aPTT in Platelet poor plasma by Coagulation assay', 'Measurement', 'LOINC', 'S', 'FALSE'),  --from extraction script
+   (3020460, '1988-5', 'C reactive protein [Mass/volume] in Serum or Plasma', 'Measurement', 'LOINC', 'S', 'FALSE'),  --from extraction script
+   (3020891, '8310-5', 'Body temperature', 'Measurement', 'LOINC', 'S', 'TRUE'),  --from extraction script
+   (3022217, '6301-6', 'INR in Platelet poor plasma by Coagulation assay', 'Measurement', 'LOINC', 'S', 'FALSE'),  --from extraction script
+   (3022893, '1916-6', 'Aspartate aminotransferase/Alanine aminotransferase [Enzymatic activity ratio] in Serum or Plasma', 'Measurement', 'LOINC', 'S', 'FALSE'),  --from extraction script
+   (3023091, '26881-3', 'Interleukin 6 [Mass/volume] in Serum or Plasma', 'Measurement', 'LOINC', 'S', 'TRUE'),  --from extraction script
+   (3023361, '7799-0', 'Deprecated Fibrin D-dimer [Units/volume] in Platelet poor plasma', 'Measurement', 'LOINC', 'N', 'TRUE'),  --from extraction script
+   (3024171, '9279-1', 'Respiratory rate', 'Measurement', 'LOINC', 'S', 'FALSE'),  --from extraction script
+   (3024929, '777-3', 'Platelets [#/volume] in Blood by Automated count', 'Measurement', 'LOINC', 'S', 'FALSE'),  --from extraction script
+   (3025315, '29463-7', 'Body weight', 'Measurement', 'LOINC', 'S', 'FALSE'),  --from extraction script
+   (3026238, '19996-8', 'Oxygen/Inspired gas Respiratory system --on ventilator', 'Measurement', 'LOINC', 'S', 'FALSE'),  --from extraction script
+   (3027018, '8867-4', 'Heart rate', 'Measurement', 'LOINC', 'S', 'FALSE'),  --from extraction script
+   (3027801, '2703-7', 'Oxygen [Partial pressure] in Arterial blood', 'Measurement', 'LOINC', 'S', 'FALSE'),  --from extraction script
+   (3034022, '42929-0', 'Lactate dehydrogenase panel - Serum or Plasma', 'Measurement', 'LOINC', 'S', 'TRUE'),  --from extraction script
+   (3034426, '5902-2', 'Prothrombin time (PT)', 'Measurement', 'LOINC', 'S', 'FALSE'),  --from extraction script
+   (3036277, '8302-2', 'Body height', 'Measurement', 'LOINC', 'S', 'FALSE'),  --from extraction script
+   (3038553, '39156-5', 'Body mass index (BMI) [Ratio]', 'Measurement', 'LOINC', 'S', 'FALSE'),  --from extraction script
+   (3045262, '45066-8', 'Creatinine and Glomerular filtration rate.predicted panel - Serum, Plasma or Blood', 'Measurement', 'LOINC', 'S', 'TRUE'),  --from extraction script
+   (3045524, '34543-9', 'Bilirubin direct and total panel [Mass/volume] - Serum or Plasma', 'Measurement', 'LOINC', 'S', 'FALSE'),  --from extraction script
+   (3046279, '33959-8', 'Procalcitonin [Mass/volume] in Serum or Plasma', 'Measurement', 'LOINC', 'S', 'FALSE'),  --from extraction script
+   (37032427, 'LP394019-6', 'Fibrinogen | Platelet poor plasma | Coagulation', 'Measurement', 'LOINC', 'C', 'TRUE'),  --from extraction script
+   (37041261, 'LP393348-0', 'Erythrocyte distribution width | Red Blood Cells | Hematology and Cell counts', 'Measurement', 'LOINC', 'C', 'TRUE'),  --from extraction script
+   (37041593, 'LP393946-1', 'aPTT | Platelet poor plasma | Coagulation', 'Measurement', 'LOINC', 'C', 'TRUE'),  --from extraction script
+   (37042222, 'LP392736-7', 'Basophils | Blood | Hematology and Cell counts', 'Measurement', 'LOINC', 'C', 'TRUE'),  --from extraction script
+   (37043992, 'LP392599-9', 'Leukocytes | Blood | Hematology and Cell counts', 'Measurement', 'LOINC', 'C', 'TRUE'),  --from extraction script
+   (37051715, 'LP394015-4', 'Fibrin D-dimer FEU | Platelet poor plasma | Coagulation', 'Measurement', 'LOINC', 'C', 'TRUE'),  --from extraction script
+   (37063873, 'LP385942-0', 'Troponin I.cardiac | Serum or Plasma | Chemistry - non-challenge', 'Measurement', 'LOINC', 'C', 'TRUE'),  --from extraction script
+   (37070108, 'LP392479-4', 'Hematocrit | Blood | Hematology and Cell counts', 'Measurement', 'LOINC', 'C', 'TRUE'),  --from extraction script
+   (37070654, 'LP385083-3', 'Ferritin | Serum or Plasma | Chemistry - non-challenge', 'Measurement', 'LOINC', 'C', 'TRUE'),  --from extraction script
+   (40652525, 'LG5272-2', 'Alanine aminotransferase|CCnc|Pt|ANYBldSerPl', 'Measurement', 'LOINC', 'C', 'TRUE'),  --from extraction script
+   (40652709, 'LG6199-6', 'Bilirubin|MCnc|Pt|ANYBldSerPl', 'Measurement', 'LOINC', 'C', 'TRUE'),  --from extraction script
+   (40652870, 'LG6657-3', 'Creatinine|MCnc|Pt|ANYBldSerPl', 'Measurement', 'LOINC', 'C', 'TRUE'),  --from extraction script
+   (40653085, 'LG7967-5', 'Glucose|MCnc|Pt|ANYBldSerPl', 'Measurement', 'LOINC', 'C', 'TRUE'),  --from extraction script
+   (40653238, 'LG6039-4', 'Lactate|SCnc|Pt|ANYBldSerPl', 'Measurement', 'LOINC', 'C', 'TRUE'),  --from extraction script
+   (40653596, 'LG10990-6', 'Potassium|SCnc|Pt|ANYBldSerPl', 'Measurement', 'LOINC', 'C', 'TRUE'),  --from extraction script
+   (40653762, 'LG11363-5', 'Sodium|SCnc|Pt|ANYBldSerPl', 'Measurement', 'LOINC', 'C', 'TRUE'),  --from extraction script
+   (40653900, 'LG1314-6', 'Urea nitrogen|MCnc|Pt|ANYBldSerPl', 'Measurement', 'LOINC', 'C', 'TRUE'),  --from extraction script
+   (40653994, 'LG32849-8', 'Eosinophils|NCnc|Pt|Bld', 'Measurement', 'LOINC', 'C', 'TRUE'),  --from extraction script
+   (40654045, 'LG32863-9', 'Lymphocytes|NCnc|Pt|Bld', 'Measurement', 'LOINC', 'C', 'TRUE'),  --from extraction script
+   (40654069, 'LG32885-2', 'Monocytes|NCnc|Pt|Bld', 'Measurement', 'LOINC', 'C', 'TRUE'),  --from extraction script
+   (40654088, 'LG32886-0', 'Neutrophils|NCnc|Pt|Bld', 'Measurement', 'LOINC', 'C', 'TRUE'),  --from extraction script
+   (40762499, '59408-5', 'Oxygen saturation in Arterial blood by Pulse oximetry', 'Measurement', 'LOINC', 'S', 'FALSE'),  --from extraction script
+   (40771922, '69405-9', 'Glomerular filtration rate/1.73 sq M.predicted [Volume Rate/Area] in Serum, Plasma or Blood', 'Measurement', 'LOINC', 'S', 'TRUE'),  --from extraction script
+   (703443, '1300671000000104', 'COVID-19 severity scale', 'Measurement', 'SNOMED', 'S', 'FALSE'),  --from extraction script
+   (4141684, '427081008', 'Delivered oxygen flow rate', 'Measurement', 'SNOMED', 'S', 'TRUE'),  --from extraction script
+   (4353936, '250774007', 'Inspired oxygen concentration', 'Measurement', 'SNOMED', 'S', 'FALSE'),  --from extraction script
+   (45889365, '1012740', 'Dialysis Services and Procedures', 'Observation', 'CPT4', 'C', 'TRUE'),  --from extraction script
+   (3046853, '32624-9', 'Race', 'Observation', 'LOINC', 'S', 'TRUE'),  --from extraction script
+   (36033639, '97155-6', 'SARS coronavirus 2 (COVID-19) immunization status', 'Observation', 'LOINC', 'S', 'TRUE'),  --from extraction script
+   (46235215, '76691-5', 'Gender identity', 'Observation', 'LOINC', 'S', 'TRUE'),  --from extraction script
+   (4039922, '229306004', 'Positive pressure therapy', 'Observation', 'SNOMED', 'S', 'TRUE'),  --from extraction script
+   (4275495, '365981007', 'Tobacco smoking behavior - finding', 'Observation', 'SNOMED', 'S', 'TRUE'),  --from extraction script
+   (4298794, '77176002', 'Smoker', 'Observation', 'SNOMED', 'S', 'TRUE'),  --from extraction script
+   (2213572, '90935', 'Hemodialysis procedure with single evaluation by a physician or other qualified health care professional', 'Procedure', 'CPT4', 'S', 'FALSE'),  --from extraction script
+   (2213573, '90937', 'Hemodialysis procedure requiring repeated evaluation(s) with or without substantial revision of dialysis prescription', 'Procedure', 'CPT4', 'S', 'FALSE'),  --from extraction script
+   (2213576, '90945', 'Dialysis procedure other than hemodialysis (eg, peritoneal dialysis, hemofiltration, or other continuous renal replacement therapies), with single evaluation by a physician or other qualified health care professional', 'Procedure', 'CPT4', 'S', 'TRUE'),  --from extraction script
+   (45889034, '1012752', 'Hemodialysis Procedures', 'Procedure', 'CPT4', 'C', 'TRUE'),  --from extraction script
+   (46257585, '1022227', 'Extracorporeal membrane oxygenation (ECMO)/extracorporeal life support (ECLS) provided by physician', 'Procedure', 'CPT4', 'C', 'TRUE'),  --from extraction script
+   (3171077, '28690001000004105', 'Emergent dialysis', 'Procedure', 'Nebraska Lexicon', 'S', 'FALSE'),  --from extraction script
+   (3655896, '870386000', 'Vasopressor therapy', 'Procedure', 'SNOMED', 'S', 'TRUE'),  --from extraction script
+   (3655950, '870533002', 'Heated and humidified high flow oxygen therapy', 'Procedure', 'SNOMED', 'S', 'FALSE'),  --from extraction script
+   (4052536, '233573008', 'Extracorporeal membrane oxygenation', 'Procedure', 'SNOMED', 'S', 'TRUE'),  --from extraction script
+   (4082249, '182714002', 'Oxygenator therapy', 'Procedure', 'SNOMED', 'S', 'FALSE'),  --from extraction script
+   (4119964, '304577004', 'Humidified oxygen therapy', 'Procedure', 'SNOMED', 'S', 'FALSE'),  --from extraction script
+   (4120120, '302497006', 'Hemodialysis', 'Procedure', 'SNOMED', 'S', 'FALSE'),  --from extraction script
+   (4146536, '265764009', 'Renal dialysis', 'Procedure', 'SNOMED', 'S', 'FALSE'),  --from extraction script
+   (4155151, '371907003', 'Oxygen administration by nasal cannula', 'Procedure', 'SNOMED', 'S', 'FALSE'),  --from extraction script
+   (4162736, '371908008', 'Oxygen administration by mask', 'Procedure', 'SNOMED', 'S', 'FALSE'),  --from extraction script
+   (4177224, '428311008', 'Noninvasive ventilation', 'Procedure', 'SNOMED', 'S', 'FALSE'),  --from extraction script
+   (4201025, '315041000', 'High concentration oxygen therapy', 'Procedure', 'SNOMED', 'S', 'FALSE'),  --from extraction script
+   (4216695, '71786000', 'Intranasal oxygen therapy', 'Procedure', 'SNOMED', 'S', 'FALSE'),  --from extraction script
+   (4230167, '40617009', 'Artificial respiration', 'Procedure', 'SNOMED', 'S', 'FALSE'),  --from extraction script
+   (4237460, '408853006', 'Intermittent positive pressure ventilation via endotracheal tube', 'Procedure', 'SNOMED', 'S', 'TRUE'),  --from extraction script
+   (4324124, '71192002', 'Peritoneal dialysis', 'Procedure', 'SNOMED', 'S', 'FALSE'),  --from extraction script
+   (37018292, '714749008', 'Continuous renal replacement therapy', 'Procedure', 'SNOMED', 'S', 'FALSE'),  --from extraction script
+   (40486624, '447837008', 'Noninvasive positive pressure ventilation', 'Procedure', 'SNOMED', 'S', 'FALSE'),  --from extraction script
+   (44790731, '240051000000102', 'Oxygen administration by non rebreather mask', 'Procedure', 'SNOMED', 'S', 'FALSE'),  --from extraction script
+   (8515, '2', 'Asian', 'Race', 'Race', 'S', 'FALSE'),  --from extraction script
+   (8516, '3', 'Black or African American', 'Race', 'Race', 'S', 'FALSE'),  --from extraction script
+   (8527, '5', 'White', 'Race', 'Race', 'S', 'FALSE'),  --from extraction script
+   (8557, '4', 'Native Hawaiian or Other Pacific Islander', 'Race', 'Race', 'S', 'FALSE'),  --from extraction script
+   (8657, '1', 'American Indian or Alaska Native', 'Race', 'Race', 'S', 'FALSE'),  --from extraction script
+   (280, '1', 'Medicare', 'Payer', 'SOPT', 'S', 'TRUE'),  --payer
+   (289, '2', 'Medicaid', 'Payer', 'SOPT', 'S', 'TRUE'),  --payer
+   (327, '5', 'Private Health Insurance', 'Payer', 'SOPT', 'S', 'TRUE'),  --payer
+   (332, '6', 'Blue Cross/Blue Shield', 'Payer', 'SOPT', 'S', 'TRUE'),  --payer
+   (340, '7', 'Managed Care, Unspecified', 'Payer', 'SOPT', 'S', 'TRUE'),  --payer
+   (375, '31', 'Department of Defense', 'Payer', 'SOPT', 'S', 'TRUE'),  --payer
+   (383, '32', 'Department of Veterans Affairs', 'Payer', 'SOPT', 'S', 'TRUE'),  --payer
+   (436, '81', 'Self-pay', 'Payer', 'SOPT', 'S', 'TRUE'),  --payer
+   (132736, '5758002', 'Bacteremia', 'Condition', 'SNOMED', 'S', 'TRUE'),  --refresh spreadsheet
+   (192671, '74474003', 'Gastrointestinal hemorrhage', 'Condition', 'SNOMED', 'S', 'TRUE'),  --refresh spreadsheet
+   (197320, '14669001', 'Acute renal failure syndrome', 'Condition', 'SNOMED', 'S', 'TRUE'),  --refresh spreadsheet
+   (197494, '50711007', 'Viral hepatitis C', 'Condition', 'SNOMED', 'S', 'TRUE'),  --refresh spreadsheet
+   (253796, '36118008', 'Pneumothorax', 'Condition', 'SNOMED', 'S', 'TRUE'),  --refresh spreadsheet
+   (254061, '60046008', 'Pleural effusion', 'Condition', 'SNOMED', 'S', 'TRUE'),  --refresh spreadsheet
+   (257315, '53084003', 'Bacterial pneumonia', 'Condition', 'SNOMED', 'S', 'TRUE'),  --refresh spreadsheet
+   (261326, '75570004', 'Viral pneumonia', 'Condition', 'SNOMED', 'S', 'TRUE'),  --refresh spreadsheet
+   (314383, '50920009', 'Myocarditis', 'Condition', 'SNOMED', 'S', 'TRUE'),  --refresh spreadsheet
+   (319835, '42343007', 'Congestive heart failure', 'Condition', 'SNOMED', 'S', 'TRUE'),  --refresh spreadsheet
+   (321042, '410429000', 'Cardiac arrest', 'Condition', 'SNOMED', 'S', 'TRUE'),  --refresh spreadsheet
+   (377091, '91175000', 'Seizure', 'Condition', 'SNOMED', 'S', 'TRUE'),  --refresh spreadsheet
+   (435785, '7180009', 'Meningitis', 'Condition', 'SNOMED', 'S', 'TRUE'),  --refresh spreadsheet
+   (436093, '67406007', 'Disseminated intravascular coagulation', 'Condition', 'SNOMED', 'S', 'TRUE'),  --refresh spreadsheet
+   (439776, '35919005', 'Autism spectrum disorder', 'Condition', 'SNOMED', 'S', 'TRUE'),  --refresh spreadsheet
+   (440417, '59282003', 'Pulmonary embolism', 'Condition', 'SNOMED', 'S', 'TRUE'),  --refresh spreadsheet
+   (441589, '56819008', 'Endocarditis', 'Condition', 'SNOMED', 'S', 'TRUE'),  --refresh spreadsheet
+   (4195694, '67782005', 'Acute respiratory distress syndrome', 'Condition', 'SNOMED', 'S', 'TRUE'),  --refresh spreadsheet
+   (4281232, '66071002', 'Type B viral hepatitis', 'Condition', 'SNOMED', 'S', 'TRUE'),  --refresh spreadsheet
+   (40401938, '205614001', '(Down syndrome - trisomy 21) or (mongolism) or (trisomy 21) or (trisomy 22)', 'Condition', 'SNOMED', 'N', 'TRUE'),  --refresh spreadsheet
+   (43530623, '1131000119105', 'Sequela of cerebrovascular accident', 'Condition', 'SNOMED', 'S', 'TRUE'),  --refresh spreadsheet
+   (43531681, '651000119108', 'Acute deep vein thrombosis of lower limb', 'Condition', 'SNOMED', 'S', 'TRUE'),  --refresh spreadsheet
+   (44784217, '698247007', 'Cardiac arrhythmia', 'Condition', 'SNOMED', 'S', 'TRUE'),  --refresh spreadsheet
+   (3473837, '426160001', 'Oxygen ventilator', 'Device', 'Nebraska Lexicon', 'N', 'TRUE'),  --refresh spreadsheet
+   (32765, 'OMOP4873976', 'Favipiravir', 'Drug', 'RxNorm', 'S', 'TRUE'),  --refresh spreadsheet
+   (33000, 'OMOP5043059', 'COVID-19 convalescent plasma', 'Drug', 'RxNorm', 'S', 'TRUE'),  --refresh spreadsheet
+   (702418, '2587300', 'tixagevimab', 'Drug', 'RxNorm', 'S', 'TRUE'),  --refresh spreadsheet
+   (702423, '2587306', 'cilgavimab', 'Drug', 'RxNorm', 'S', 'TRUE'),  --refresh spreadsheet
+   (702530, '2587892', 'nirmatrelvir', 'Drug', 'RxNorm', 'S', 'TRUE'),  --refresh spreadsheet
+   (702536, '2587901', 'molnupiravir', 'Drug', 'RxNorm', 'S', 'TRUE'),  --refresh spreadsheet
+   (1101554, '2683', 'colchicine', 'Drug', 'RxNorm', 'S', 'TRUE'),  --refresh spreadsheet
+   (1114375, '72435', 'anakinra', 'Drug', 'RxNorm', 'S', 'TRUE'),  --refresh spreadsheet
+   (1235357, 'OMOP5216063', 'nirmatrelvir / ritonavir Oral Tablet', 'Drug', 'RxNorm', 'S', 'TRUE'),  --refresh spreadsheet
+   (1510627, '2047232', 'baricitinib', 'Drug', 'RxNorm', 'S', 'TRUE'),  --refresh spreadsheet
+   (1518254, '3264', 'dexamethasone', 'Drug', 'RxNorm', 'S', 'TRUE'),  --refresh spreadsheet
+   (1536976, '2550731', 'sotrovimab', 'Drug', 'RxNorm', 'S', 'TRUE'),  --refresh spreadsheet
+   (1734104, '18631', 'azithromycin', 'Drug', 'RxNorm', 'S', 'TRUE'),  --refresh spreadsheet
+   (1748921, '85762', 'ritonavir', 'Drug', 'RxNorm', 'S', 'TRUE'),  --refresh spreadsheet
+   (1759073, '2592360', 'bebtelovimab', 'Drug', 'RxNorm', 'S', 'TRUE'),  --refresh spreadsheet
+   (1777087, '5521', 'hydroxychloroquine', 'Drug', 'RxNorm', 'S', 'TRUE'),  --refresh spreadsheet
+   (1784444, '6069', 'ivermectin', 'Drug', 'RxNorm', 'S', 'TRUE'),  --refresh spreadsheet
+   (37499271, '2284718', 'remdesivir', 'Drug', 'RxNorm', 'S', 'TRUE'),  --refresh spreadsheet
+   (40171288, '612865', 'tocilizumab', 'Drug', 'RxNorm', 'S', 'TRUE'),  --refresh spreadsheet
+   (3018198, '7889-9', 'Francisella tularensis IgG Ab [Presence] in Serum', 'Measurement', 'LOINC', 'S', 'FALSE'),  --refresh spreadsheet
+   (3025634, '29908-1', 'Parainfluenza virus 1 RNA [Presence] in Specimen by NAA with probe detection', 'Measurement', 'LOINC', 'S', 'FALSE'),  --refresh spreadsheet
+   (36205488, 'LP260072-6', 'Galactomannan | Bronchoalveolar lavage', 'Measurement', 'LOINC', 'N', 'FALSE'),  --refresh spreadsheet
+   (36207253, 'LP256485-6', 'Histoplasma capsulatum | Urine', 'Measurement', 'LOINC', 'N', 'FALSE'),  --refresh spreadsheet
+   (37024394, 'LP378559-1', 'Influenza virus B RNA | XXX | Microbiology', 'Measurement', 'LOINC', 'C', 'FALSE'),  --refresh spreadsheet
+   (37024723, 'LP380002-8', 'Herpes virus 6 DNA panel | XXX | Microbiology Panels', 'Measurement', 'LOINC', 'C', 'FALSE'),  --refresh spreadsheet
+   (37025945, 'LP377195-5', 'Human coronavirus RNA | XXX | Microbiology', 'Measurement', 'LOINC', 'C', 'FALSE'),  --refresh spreadsheet
+   (37033649, 'LP376244-2', 'Galactomannan Ag | Serum or Plasma | Microbiology', 'Measurement', 'LOINC', 'C', 'FALSE'),  --refresh spreadsheet
+   (37049794, 'LP382722-9', 'Alkaline phosphatase | Serum or Plasma | Chemistry - non-challenge', 'Measurement', 'LOINC', 'C', 'FALSE'),  --refresh spreadsheet
+   (37050195, 'LP377083-3', 'Adenovirus DNA | XXX | Microbiology', 'Measurement', 'LOINC', 'C', 'FALSE'),  --refresh spreadsheet
+   (37050664, 'LP378502-1', 'Influenza virus A RNA | XXX | Microbiology', 'Measurement', 'LOINC', 'C', 'FALSE'),  --refresh spreadsheet
+   (37055446, 'LP378971-8', 'Rhinovirus RNA | XXX | Microbiology', 'Measurement', 'LOINC', 'C', 'FALSE'),  --refresh spreadsheet
+   (37065137, 'LP378960-1', 'Respiratory syncytial virus RNA | XXX | Microbiology', 'Measurement', 'LOINC', 'C', 'FALSE'),  --refresh spreadsheet
+   (37068812, 'LP378241-6', 'Human metapneumovirus RNA | XXX | Microbiology', 'Measurement', 'LOINC', 'C', 'FALSE'),  --refresh spreadsheet
+   (37069484, 'LP376381-2', 'Histoplasma capsulatum Ag | Serum | Microbiology', 'Measurement', 'LOINC', 'C', 'FALSE'),  --refresh spreadsheet
+   (37075814, 'LP379721-6', '13 beta glucan | Serum | Microbiology', 'Measurement', 'LOINC', 'C', 'TRUE'),  --refresh spreadsheet
+   (40773382, 'LP43012-1', 'Coccidioides immitis IgG | Bld-Ser-Plas', 'Measurement', 'LOINC', 'N', 'FALSE'),  --refresh spreadsheet
+   (40796545, 'LP43013-9', 'Coccidioides immitis IgM | Bld-Ser-Plas', 'Measurement', 'LOINC', 'N', 'FALSE'),  --refresh spreadsheet
+   (4203942, '52870002', 'Admitting diagnosis', 'Observation', 'SNOMED', 'S', 'FALSE')  --refresh spreadsheet
+;

--- a/Cohort curation scripts/02_CURE_ID_All_Tables.sql
+++ b/Cohort curation scripts/02_CURE_ID_All_Tables.sql
@@ -1,6 +1,6 @@
 /*
 Create CURE_ID tables based off generated CURE_ID cohort
-This script depends on CURE_ID_Cohort.sql, and must be run after that script compeltes
+This script depends on CURE_ID_Cohort.sql, and must be run after that script completes
 */
 USE YOUR_DATABASE;
 

--- a/Cohort curation scripts/07_B_measurement_profile.sql
+++ b/Cohort curation scripts/07_B_measurement_profile.sql
@@ -1,113 +1,519 @@
---Create table which includes the measurement concepts included in the cohort and their names
-DROP TABLE IF EXISTS #measurement_parent_concepts_of_interest;
+-------------------------------------
+--Drug Exposure Profile Tool
+-----------------------------------
+ 
+
+
+drop table if exists [Results].[cure_id_drugs_of_interest];
+create table [Results].[cure_id_drugs_of_interest] (drug_category varchar(255),
+                                                    concept_id int not null,
+                                                    drug_description varchar(512));
+
+insert into [Results].[cure_id_drugs_of_interest] (drug_category, concept_id, drug_description) values
+   ('nirmatrelvir and ritonavir', 780186, '{10 (nirmatrelvir 150 MG Oral Tablet) / 10 (ritonavir 100 MG Oral Tablet) } Pack [Paxlovid 150 MG /100 MG Dose Pack]'),
+   ('nirmatrelvir and ritonavir', 780185, '{10 (nirmatrelvir 150 MG Oral Tablet) / 10 (ritonavir 100 MG Oral Tablet) } Pack'),
+   ('nirmatrelvir and ritonavir', 702577, '{20 (nirmatrelvir 150 MG Oral Tablet) / 10 (ritonavir 100 MG Oral Tablet) } Pack'),
+   ('nirmatrelvir and ritonavir', 702578, '{20 (nirmatrelvir 150 MG Oral Tablet) / 10 (ritonavir 100 MG Oral Tablet) } Pack [Paxlovid 5-Day]'),
+   ('nirmatrelvir and ritonavir', 702530, 'nirmatrelvir'),
+   ('nirmatrelvir and ritonavir', 702531, 'nirmatrelvir 150 MG'),
+   ('nirmatrelvir and ritonavir', 702535, 'nirmatrelvir 150 MG Oral Tablet'),
+   ('nirmatrelvir and ritonavir', 702534, 'nirmatrelvir Oral Tablet'),
+   ('remdesivir', 37499272, 'remdesivir 100 MG'),
+   ('remdesivir', 36057819, 'remdesivir 100 MG Injectable Solution Box of 1'),
+   ('remdesivir', 36057825, 'remdesivir 100 MG Injectable Solution [Veklury]'),
+   ('remdesivir', 35896882, 'remdesivir 100 MG Injectable Solution [Veklury]'),
+   ('remdesivir', 35896880, 'remdesivir 100 MG Injectable Solution [Veklury] Box of 1'),
+   ('remdesivir', 36057823, 'remdesivir 100 MG Injectable Solution [Veklury] Box of 1'),
+   ('remdesivir', 36057811, 'remdesivir 100 MG Injection Box of 1'),
+   ('remdesivir', 37002796, 'remdesivir 100 MG Injection [Veklury]'),
+   ('remdesivir', 36057814, 'remdesivir 100 MG Injection [Veklury] Box of 1'),
+   ('remdesivir', 36074072, 'remdesivir 150 MG'),
+   ('remdesivir', 36057828, 'remdesivir 150 MG Injectable Solution Box of 1'),
+   ('remdesivir', 1145689, 'remdesivir 5 MG/ML'),
+   ('remdesivir', 36074073, 'remdesivir 5 MG/ML Injectable Solution Box of 1'),
+   ('remdesivir', 36074076, 'remdesivir 5 MG/ML Injectable Solution [Veklury]'),
+   ('remdesivir', 35896884, 'remdesivir 5 MG/ML Injectable Solution [Veklury]'),
+   ('remdesivir', 35896883, 'remdesivir 5 MG/ML Injectable Solution [Veklury] Box of 1'),
+   ('remdesivir', 36074075, 'remdesivir 5 MG/ML Injectable Solution [Veklury] Box of 1'),
+   ('remdesivir', 37002798, 'remdesivir 5 MG/ML Injection [Veklury]'),
+   ('remdesivir', 36057833, 'remdesivir Injectable Solution'),
+   ('remdesivir', 37499274, 'remdesivir Injection'),
+   ('Molnupiravir', 702536, 'molnupiravir'),
+   ('Molnupiravir', 702537, 'molnupiravir 200 MG'),
+   ('Molnupiravir', 779914, 'molnupiravir 200 MG [Lagevrio]'),
+   ('Molnupiravir', 702541, 'molnupiravir 200 MG Oral Capsule'),
+   ('Molnupiravir', 779918, 'molnupiravir 200 MG Oral Capsule [Lagevrio]'),
+   ('Molnupiravir', 702540, 'molnupiravir Oral Capsule'),
+   ('Molnupiravir', 779917, 'molnupiravir Oral Capsule [Lagevrio]'),
+   ('Molnupiravir', 702538, 'molnupiravir Oral Product'),
+   ('Molnupiravir', 702539, 'molnupiravir Pill'),
+   ('Favipiravir', 32765, 'Favipiravir'),
+   ('Favipiravir', 36061098, 'Favipiravir 200 MG'),
+   ('Favipiravir', 36061099, 'Favipiravir 200 MG [Avigan]'),
+   ('Favipiravir', 36061095, 'Favipiravir 200 MG Oral Tablet'),
+   ('Favipiravir', 36061097, 'Favipiravir 200 MG Oral Tablet [Avigan]'),
+   ('Favipiravir', 36061096, 'Favipiravir 200 MG Oral Tablet [Avigan] Box of 100'),
+   ('Favipiravir', 36061094, 'Favipiravir 200 MG Oral Tablet Box of 100'),
+   ('Favipiravir', 36061100, 'Favipiravir Oral Tablet'),
+   ('Favipiravir', 36061101, 'Favipiravir Oral Tablet [Avigan]'),
+   ('Lopinavir and ritonavir', 19048073, 'lopinavir 100 MG / ritonavir 25 MG [Kaletra]'),
+   ('Lopinavir and ritonavir', 1748985, 'lopinavir 100 MG / ritonavir 25 MG Oral Tablet'),
+   ('Lopinavir and ritonavir', 1748987, 'lopinavir 100 MG / ritonavir 25 MG Oral Tablet [Kaletra]'),
+   ('Lopinavir and ritonavir', 19048077, 'lopinavir 133 MG / ritonavir 33.3 MG [Kaletra]'),
+   ('Lopinavir and ritonavir', 1748955, 'lopinavir 133 MG / ritonavir 33.3 MG Oral Capsule'),
+   ('Lopinavir and ritonavir', 1748989, 'lopinavir 133 MG / ritonavir 33.3 MG Oral Capsule [Kaletra]'),
+   ('Lopinavir and ritonavir', 19048071, 'lopinavir 200 MG / ritonavir 50 MG [Kaletra]'),
+   ('Lopinavir and ritonavir', 19125242, 'lopinavir 200 MG / ritonavir 50 MG Oral Capsule'),
+   ('Lopinavir and ritonavir', 19122186, 'lopinavir 200 MG / ritonavir 50 MG Oral Tablet'),
+   ('Lopinavir and ritonavir', 1748986, 'lopinavir 200 MG / ritonavir 50 MG Oral Tablet [Kaletra]'),
+   ('Lopinavir and ritonavir', 19048075, 'lopinavir 80 MG/ML / ritonavir 20 MG/ML [Kaletra]'),
+   ('Lopinavir and ritonavir', 1748956, 'lopinavir 80 MG/ML / ritonavir 20 MG/ML Oral Solution'),
+   ('Lopinavir and ritonavir', 1748988, 'lopinavir 80 MG/ML / ritonavir 20 MG/ML Oral Solution [Kaletra]'),
+   ('Lopinavir and ritonavir', 40059335, 'lopinavir / ritonavir Oral Capsule'),
+   ('Lopinavir and ritonavir', 40160001, 'lopinavir / ritonavir Oral Capsule [Kaletra]'),
+   ('Lopinavir and ritonavir', 40059337, 'lopinavir / ritonavir Oral Solution'),
+   ('Lopinavir and ritonavir', 40160002, 'lopinavir / ritonavir Oral Solution [Kaletra]'),
+   ('Lopinavir and ritonavir', 40128015, 'lopinavir / ritonavir Oral Tablet'),
+   ('Lopinavir and ritonavir', 40160004, 'lopinavir / ritonavir Oral Tablet [Kaletra]'),
+   ('Ivermectin', 36232554, 'Stromectol Oral Product'),
+   ('Ivermectin', 36232555, 'Stromectol Pill'),
+   ('Ivermectin', 19085038, 'ivermectin 3 MG'),
+   ('Ivermectin', 36227067, 'ivermectin Oral Product'),
+   ('Ivermectin', 36227069, 'ivermectin Pill'),
+   ('Ivermectin', 19081725, 'ivermectin 3 MG [Stromectol]'),
+   ('Ivermectin', 40053195, 'ivermectin Oral Tablet [Stromectol]'),
+   ('Ivermectin', 40053194, 'ivermectin Oral Tablet'),
+   ('Hydroxychloroquine', 1777087, 'hydroxychloroquine'),
+   ('Hydroxychloroquine', 40051595, 'hydroxychloroquine Oral Tablet'),
+   ('Hydroxychloroquine', 40051596, 'hydroxychloroquine Oral Tablet [Plaquenil]'),
+   ('Hydroxychloroquine', 40184083, 'hydroxychloroquine sulfate 200 MG'),
+   ('Hydroxychloroquine', 40184084, 'hydroxychloroquine sulfate 200 MG Oral Tablet'),
+   ('Hydroxychloroquine', 40184085, 'hydroxychloroquine sulfate 200 MG Oral Tablet [Plaquenil]'),
+   ('Hydroxychloroquine', 40184087, 'hydroxychloroquine sulfate 200 MG [Plaquenil]'),
+   ('Hydroxychloroquine', 40051597, 'hydroxychloroquine Oral Tablet [Quineprox]'),
+   ('Hydroxychloroquine', 701777, 'hydroxychloroquine sulfate 100 MG'),
+   ('Hydroxychloroquine', 701778, 'hydroxychloroquine sulfate 100 MG Oral Tablet'),
+   ('Hydroxychloroquine', 40184086, 'hydroxychloroquine sulfate 200 MG Oral Tablet [Quineprox]'),
+   ('Hydroxychloroquine', 40184088, 'hydroxychloroquine sulfate 200 MG [Quineprox]'),
+   ('Hydroxychloroquine', 701779, 'hydroxychloroquine sulfate 300 MG'),
+   ('Hydroxychloroquine', 701780, 'hydroxychloroquine sulfate 300 MG Oral Tablet'),
+   ('Hydroxychloroquine', 40242199, 'hydroxychloroquine sulfate 400 MG'),
+   ('Hydroxychloroquine', 40242200, 'hydroxychloroquine sulfate 400 MG Oral Tablet'),
+   ('Dexamethasone', 1518254, 'dexamethasone'),
+   ('Dexamethasone', 40028260, 'dexamethasone Injectable Solution'),
+   ('Dexamethasone', 40241503, 'dexamethasone phosphate 4 MG/ML'),
+   ('Dexamethasone', 40241504, 'dexamethasone phosphate 4 MG/ML Injectable Solution'),
+   ('Dexamethasone', 40028601, 'dexamethasone Oral Tablet'),
+   ('Dexamethasone', 40028602, 'dexamethasone Oral Tablet [Decadron]'),
+   ('Dexamethasone', 1518608, 'dexamethasone 4 MG'),
+   ('Dexamethasone', 19117916, 'dexamethasone 4 MG [Decadron]'),
+   ('Dexamethasone', 1518292, 'dexamethasone 4 MG Oral Tablet'),
+   ('Dexamethasone', 19030003, 'dexamethasone 4 MG Oral Tablet [Decadron]'),
+   ('Dexamethasone', 1518607, 'dexamethasone 1.5 MG'),
+   ('Dexamethasone', 19117914, 'dexamethasone 1.5 MG [Decadron]'),
+   ('Dexamethasone', 19018906, 'dexamethasone 1.5 MG Oral Tablet'),
+   ('Dexamethasone', 19030001, 'dexamethasone 1.5 MG Oral Tablet [Decadron]'),
+   ('Dexamethasone', 1518609, 'dexamethasone 6 MG'),
+   ('Dexamethasone', 19117921, 'dexamethasone 6 MG [Decadron]'),
+   ('Dexamethasone', 1518293, 'dexamethasone 6 MG Oral Tablet'),
+   ('Dexamethasone', 19030008, 'dexamethasone 6 MG Oral Tablet [Decadron]'),
+   ('Dexamethasone', 1518606, 'dexamethasone 1 MG'),
+   ('Dexamethasone', 1518259, 'dexamethasone 1 MG Oral Tablet'),
+   ('Dexamethasone', 1719011, 'dexamethasone phosphate 10 MG/ML'),
+   ('Dexamethasone', 19076145, 'dexamethasone phosphate 10 MG/ML Injectable Solution'),
+   ('Dexamethasone', 1518603, 'dexamethasone 0.1 MG/ML'),
+   ('Dexamethasone', 19088972, 'dexamethasone 0.1 MG/ML [Decadron]'),
+   ('Dexamethasone', 19076136, 'dexamethasone 0.1 MG/ML Oral Solution'),
+   ('Dexamethasone', 1518851, 'dexamethasone 0.1 MG/ML Oral Solution [Decadron]'),
+   ('Dexamethasone', 40028599, 'dexamethasone Oral Solution'),
+   ('Dexamethasone', 40146415, 'dexamethasone Oral Solution [Decadron]'),
+   ('Baricitinib', 1510627, 'baricitinib'),
+   ('Baricitinib', 37497352, 'baricitinib 1 MG'),
+   ('Baricitinib', 37497354, 'baricitinib 1 MG [Olumiant]'),
+   ('Baricitinib', 37497353, 'baricitinib 1 MG Oral Tablet'),
+   ('Baricitinib', 37497355, 'baricitinib 1 MG Oral Tablet [Olumiant]'),
+   ('Baricitinib', 1510628, 'baricitinib 2 MG'),
+   ('Baricitinib', 1510634, 'baricitinib 2 MG [Olumiant]'),
+   ('Baricitinib', 1510632, 'baricitinib 2 MG Oral Tablet'),
+   ('Baricitinib', 1510638, 'baricitinib 2 MG Oral Tablet [Olumiant]'),
+   ('Baricitinib', 1758612, 'baricitinib 4 MG'),
+   ('Baricitinib', 779706, 'baricitinib 4 MG [Olumiant]'),
+   ('Baricitinib', 1758613, 'baricitinib 4 MG Oral Tablet'),
+   ('Baricitinib', 779707, 'baricitinib 4 MG Oral Tablet [Olumiant]'),
+   ('Baricitinib', 1510631, 'baricitinib Oral Tablet'),
+   ('Baricitinib', 1510635, 'baricitinib Oral Tablet [Olumiant]'),
+   ('Tocilizumab', 1356447, '0.9 ML tocilizumab 180 MG/ML Auto-Injector'),
+   ('Tocilizumab', 1356448, '0.9 ML tocilizumab 180 MG/ML Auto-Injector [Actemra]'),
+   ('Tocilizumab', 44507566, '0.9 ML tocilizumab 180 MG/ML Prefilled Syringe'),
+   ('Tocilizumab', 44507562, '0.9 ML tocilizumab 180 MG/ML Prefilled Syringe [Actemra]'),
+   ('Tocilizumab', 46275121, '10 ML tocilizumab 20 MG/ML Injection'),
+   ('Tocilizumab', 46275122, '10 ML tocilizumab 20 MG/ML Injection [Actemra]'),
+   ('Tocilizumab', 46275123, '20 ML tocilizumab 20 MG/ML Injection'),
+   ('Tocilizumab', 46275124, '20 ML tocilizumab 20 MG/ML Injection [Actemra]'),
+   ('Tocilizumab', 46275116, '4 ML tocilizumab 20 MG/ML Injection'),
+   ('Tocilizumab', 46275118, '4 ML tocilizumab 20 MG/ML Injection [Actemra]'),
+   ('Tocilizumab', 40171288, 'tocilizumab'),
+   ('Tocilizumab', 44507701, 'tocilizumab 180 MG/ML'),
+   ('Tocilizumab', 44507704, 'tocilizumab 180 MG/ML [Actemra]'),
+   ('Tocilizumab', 1355866, 'tocilizumab 180 MG/ML Auto-Injector'),
+   ('Tocilizumab', 1355867, 'tocilizumab 180 MG/ML Auto-Injector [Actemra]'),
+   ('Tocilizumab', 44507702, 'tocilizumab 180 MG/ML Prefilled Syringe'),
+   ('Tocilizumab', 44507703, 'tocilizumab 180 MG/ML Prefilled Syringe [Actemra]'),
+   ('Tocilizumab', 40171289, 'tocilizumab 20 MG/ML'),
+   ('Tocilizumab', 40171292, 'tocilizumab 20 MG/ML [Actemra]'),
+   ('Tocilizumab', 46275119, 'tocilizumab 20 MG/ML Injection'),
+   ('Tocilizumab', 46275120, 'tocilizumab 20 MG/ML Injection [Actemra]'),
+   ('Tocilizumab', 1355864, 'tocilizumab Auto-Injector'),
+   ('Tocilizumab', 1355865, 'tocilizumab Auto-Injector [Actemra]'),
+   ('Tocilizumab', 46275115, 'tocilizumab Injection'),
+   ('Tocilizumab', 46275117, 'tocilizumab Injection [Actemra]'),
+   ('Tocilizumab', 44507705, 'tocilizumab Prefilled Syringe'),
+   ('Tocilizumab', 44507706, 'tocilizumab Prefilled Syringe [Actemra]'),
+   ('Colchicine', 1101554, 'colchicine'),
+   ('Colchicine', 1101586, 'colchicine 0.6 MG'),
+   ('Colchicine', 40164493, 'colchicine 0.6 MG [Colcrys]'),
+   ('Colchicine', 1101556, 'colchicine 0.6 MG Oral Tablet'),
+   ('Colchicine', 40164492, 'colchicine 0.6 MG Oral Tablet [Colcrys]'),
+   ('Colchicine', 40031428, 'colchicine Oral Tablet'),
+   ('Colchicine', 40164494, 'colchicine Oral Tablet [Colcrys]'),
+   ('Colchicine', 1101560, 'allopurinol 100 MG / colchicine 0.5 MG Oral Tablet'),
+   ('Colchicine', 19061795, 'allopurinol 300 MG / colchicine 0.5 MG Extended Release Oral Capsule'),
+   ('Colchicine', 40005863, 'allopurinol / colchicine Extended Release Oral Capsule'),
+   ('Colchicine', 40005864, 'allopurinol / colchicine Oral Tablet'),
+   ('Colchicine', 1101588, 'colchicine 0.001 MG/MG'),
+   ('Colchicine', 19060123, 'colchicine 0.001 MG/MG / podophyllin 0.02 MG/MG Topical Ointment'),
+   ('Colchicine', 1366576, 'colchicine 0.12 MG/ML'),
+   ('Colchicine', 1361345, 'colchicine 0.12 MG/ML [Gloperba]'),
+   ('Colchicine', 1366579, 'colchicine 0.12 MG/ML Oral Solution'),
+   ('Colchicine', 1361349, 'colchicine 0.12 MG/ML Oral Solution [Gloperba]'),
+   ('Colchicine', 19099374, 'colchicine 0.25 MG'),
+   ('Colchicine', 19002015, 'colchicine 0.25 MG Oral Tablet'),
+   ('Colchicine', 19109346, 'colchicine 0.432 MG'),
+   ('Colchicine', 19108528, 'colchicine 0.432 MG Oral Tablet'),
+   ('Colchicine', 1101585, 'colchicine 0.54 MG'),
+   ('Colchicine', 19075823, 'colchicine 0.54 MG Oral Tablet'),
+   ('Colchicine', 1101583, 'colchicine 0.5 MG'),
+   ('Colchicine', 1101584, 'colchicine 0.5 MG/ML'),
+   ('Colchicine', 1101557, 'colchicine 0.5 MG/ML Injectable Solution'),
+   ('Colchicine', 19018901, 'colchicine 0.5 MG Oral Tablet'),
+   ('Colchicine', 1151424, 'colchicine 0.5 MG / probenecid 500 MG Oral Tablet'),
+   ('Colchicine', 1101587, 'colchicine 0.65 MG'),
+   ('Colchicine', 19075824, 'colchicine 0.65 MG Oral Tablet'),
+   ('Colchicine', 45776979, 'colchicine 0.6 MG [Mitigare]'),
+   ('Colchicine', 45776977, 'colchicine 0.6 MG Oral Capsule'),
+   ('Colchicine', 45776981, 'colchicine 0.6 MG Oral Capsule [Mitigare]'),
+   ('Colchicine', 1101589, 'colchicine 1 MG'),
+   ('Colchicine', 1101558, 'colchicine 1 MG Oral Tablet'),
+   ('Colchicine', 40031427, 'colchicine Injectable Solution'),
+   ('Colchicine', 45776976, 'colchicine Oral Capsule'),
+   ('Colchicine', 45776980, 'colchicine Oral Capsule [Mitigare]'),
+   ('Colchicine', 1366578, 'colchicine Oral Solution'),
+   ('Colchicine', 1361346, 'colchicine Oral Solution [Gloperba]'),
+   ('Colchicine', 40031406, 'colchicine / podophyllin Topical Ointment'),
+   ('Azithromycin', 1734104, 'azithromycin'),
+   ('Azithromycin', 40013068, 'azithromycin Oral Tablet'),
+   ('Azithromycin', 40013069, 'azithromycin Oral Tablet [Zithromax]'),
+   ('Azithromycin', 19128020, '{6 (azithromycin 250 MG Oral Tablet) } Pack'),
+   ('Azithromycin', 19128124, '{6 (azithromycin 250 MG Oral Tablet [Zithromax]) } Pack [Z-PAK]'),
+   ('Azithromycin', 1734140, 'azithromycin 250 MG'),
+   ('Azithromycin', 19073777, 'azithromycin 250 MG Oral Tablet'),
+   ('Azithromycin', 1734132, 'azithromycin 250 MG Oral Tablet [Zithromax]'),
+   ('Azithromycin', 19116114, 'azithromycin 250 MG [Zithromax]'),
+   ('Azithromycin', 19128018, '{3 (azithromycin 500 MG Oral Tablet) } Pack'),
+   ('Azithromycin', 19128131, '{3 (azithromycin 500 MG Oral Tablet [Zithromax]) } Pack [TRI-PAK]'),
+   ('Azithromycin', 19085757, 'azithromycin 500 MG'),
+   ('Azithromycin', 1734134, 'azithromycin 500 MG Oral Tablet'),
+   ('Azithromycin', 1734133, 'azithromycin 500 MG Oral Tablet [Zithromax]'),
+   ('Azithromycin', 19120522, 'azithromycin 500 MG [Zithromax]'),
+   ('Azithromycin', 19133860, '{3 (azithromycin 250 MG Oral Tablet) } Pack'),
+   ('Azithromycin', 19133861, '{3 (azithromycin 250 MG Oral Tablet [Zithromax]) } Pack [Z-Pak Sample]'),
+   ('Azithromycin', 19128019, '{6 (azithromycin 250 MG Oral Capsule) } Pack'),
+   ('Azithromycin', 19108236, 'azithromycin 1000 MG'),
+   ('Azithromycin', 19106272, 'azithromycin 1000 MG Oral Tablet'),
+   ('Azithromycin', 40164101, 'azithromycin 1000 MG Powder for Oral Suspension'),
+   ('Azithromycin', 40164102, 'azithromycin 1000 MG Powder for Oral Suspension [Zithromax]'),
+   ('Azithromycin', 40221346, 'azithromycin 1000 MG [Zithromax]'),
+   ('Azithromycin', 19126614, 'azithromycin 10 MG/ML'),
+   ('Azithromycin', 19126616, 'azithromycin 10 MG/ML [AzaSite]'),
+   ('Azithromycin', 19126615, 'azithromycin 10 MG/ML Ophthalmic Solution'),
+   ('Azithromycin', 19126617, 'azithromycin 10 MG/ML Ophthalmic Solution [AzaSite]'),
+   ('Azithromycin', 19128200, 'azithromycin 10 MG/ML Ophthalmic Suspension'),
+   ('Azithromycin', 1734139, 'azithromycin 20 MG/ML'),
+   ('Azithromycin', 19073776, 'azithromycin 20 MG/ML Oral Suspension'),
+   ('Azithromycin', 19046028, 'azithromycin 20 MG/ML Oral Suspension [Zithromax]'),
+   ('Azithromycin', 19038753, 'azithromycin 20 MG/ML [Zithromax]'),
+   ('Azithromycin', 19123885, 'azithromycin 250 MG [Azinthromycin]'),
+   ('Azithromycin', 1734107, 'azithromycin 250 MG Oral Capsule'),
+   ('Azithromycin', 19006685, 'azithromycin 250 MG Oral Capsule [Zithromax]'),
+   ('Azithromycin', 19123886, 'azithromycin 250 MG Oral Tablet [Azinthromycin]'),
+   ('Azithromycin', 19113148, 'azithromycin 250 MG Oral Tablet [ZPAK]'),
+   ('Azithromycin', 19113147, 'azithromycin 250 MG [ZPAK]'),
+   ('Azithromycin', 1734167, 'azithromycin 33.3 MG/ML'),
+   ('Azithromycin', 1734168, 'azithromycin 33.3 MG/ML Extended Release Suspension'),
+   ('Azithromycin', 1734169, 'azithromycin 33.3 MG/ML Extended Release Suspension [Zmax]'),
+   ('Azithromycin', 19121228, 'azithromycin 33.3 MG/ML Oral Suspension'),
+   ('Azithromycin', 19122010, 'azithromycin 33.3 MG/ML [Zmax]'),
+   ('Azithromycin', 19080954, 'azithromycin 40 MG/ML'),
+   ('Azithromycin', 1734108, 'azithromycin 40 MG/ML Oral Suspension'),
+   ('Azithromycin', 19006686, 'azithromycin 40 MG/ML Oral Suspension [Zithromax]'),
+   ('Azithromycin', 19116115, 'azithromycin 40 MG/ML [Zithromax]'),
+   ('Azithromycin', 35603389, 'azithromycin 500 MG Injection'),
+   ('Azithromycin', 35603391, 'azithromycin 500 MG Injection [Zithromax]'),
+   ('Azithromycin', 19108237, 'azithromycin 50 MG'),
+   ('Bebtelovimab', 1759259, '2 ML bebtelovimab 87.5 MG/ML Injection'),
+   ('Bebtelovimab', 1759073, 'bebtelovimab'),
+   ('Bebtelovimab', 1759074, 'bebtelovimab 87.5 MG/ML'),
+   ('Bebtelovimab', 1759077, 'bebtelovimab 87.5 MG/ML Injection'),
+   ('Bebtelovimab', 1759076, 'bebtelovimab Injection'),
+   ('Tixagevimab and cilgavimab', 702575, '{1 (1.5 ML cilgavimab 100 MG/ML Injection) / 1 (1.5 ML tixagevimab 100 MG/ML Injection) } Pack'),
+   ('Tixagevimab and cilgavimab', 702576, '{1 (1.5 ML cilgavimab 100 MG/ML Injection) / 1 (1.5 ML tixagevimab 100 MG/ML Injection) } Pack [Evusheld 2 vial carton]'),
+   ('Tixagevimab and cilgavimab', 702580, '1.5 ML tixagevimab 100 MG/ML Injection'),
+   ('Tixagevimab and cilgavimab', 702418, 'tixagevimab'),
+   ('Tixagevimab and cilgavimab', 702419, 'tixagevimab 100 MG/ML'),
+   ('Tixagevimab and cilgavimab', 702422, 'tixagevimab 100 MG/ML Injection'),
+   ('Tixagevimab and cilgavimab', 702421, 'tixagevimab Injection'),
+   ('Tixagevimab and cilgavimab', 702649, '1.5 ML cilgavimab 100 MG/ML Injection'),
+   ('Tixagevimab and cilgavimab', 702423, 'cilgavimab'),
+   ('Tixagevimab and cilgavimab', 702424, 'cilgavimab 100 MG/ML'),
+   ('Tixagevimab and cilgavimab', 702427, 'cilgavimab 100 MG/ML Injection'),
+   ('Tixagevimab and cilgavimab', 702425, 'cilgavimab Injectable Product'),
+   ('Tixagevimab and cilgavimab', 702426, 'cilgavimab Injection'),
+   ('Sotrovimab', 1537593, '8 ML sotrovimab 62.5 MG/ML Injection'),
+   ('Sotrovimab', 1536976, 'sotrovimab'),
+   ('Sotrovimab', 1536986, 'sotrovimab 62.5 MG/ML'),
+   ('Sotrovimab', 1536989, 'sotrovimab 62.5 MG/ML Injection'),
+   ('Sotrovimab', 1536988, 'sotrovimab Injection'),
+   ('Anakinra', 1114379, '0.67 ML anakinra 149 MG/ML Prefilled Syringe'),
+   ('Anakinra', 1114380, '0.67 ML anakinra 149 MG/ML Prefilled Syringe [Kineret]'),
+   ('Anakinra', 1114375, 'anakinra'),
+   ('Anakinra', 19127200, 'anakinra 149 MG/ML'),
+   ('Anakinra', 19033445, 'anakinra 149 MG/ML [Kineret]'),
+   ('Anakinra', 42902611, 'anakinra 149 MG/ML Prefilled Syringe'),
+   ('Anakinra', 42902489, 'anakinra 149 MG/ML Prefilled Syringe [Kineret]'),
+   ('Anakinra', 40141482, 'anakinra Prefilled Syringe'),
+   ('Anakinra', 40141483, 'anakinra Prefilled Syringe [Kineret]')
+;
+
+
+--Create table of all drugs given in the cohort
+DROP TABLE IF EXISTS #drug_concepts_of_interest;
+select distinct
+    concept_id,
+    concept_name
+into 
+    #drug_concepts_of_interest
+FROM
+     [Results].[deident_CURE_ID_drug_exposure]
+    left join 
+        CONCEPT 
+    on
+        concept_id = drug_concept_id
+;
+ 
+
+---Roll up drugs into ingredients
+drop table if exists #ingredients_of_interest
 select 
-    descendant_concept_id as concept_id
-    ,ancestor_concept_id
-    ,concept_name
-into #measurement_parent_concepts_of_interest
-
-from [Results].[cure_id_concepts]
-INNER JOIN CONCEPT_ANCESTOR 
-	ON ancestor_concept_id =concept_id
-where 
-	domain  = 'Measurement' 
-	and (include_descendants = 'TRUE' or ancestor_concept_id = descendant_concept_id)
-order by concept_name
-
-
---The measurement_count_temp table counts the number of times that each concept is present for each patient in the cohort.
---It is rolled up into ancestor concepts grouped as above
---If no records for the patient of that concept are present, a record of 0 will be present 
-DROP TABLE IF EXISTS #measurement_count_temp;
-select 
-    p.person_id
-    ,mpci.ancestor_concept_id as concept_id
-    ,mpci.concept_name
-    ,count(case when m.measurement_concept_id is not null then 1 else NULL end) as concept_count
-into #measurement_count_temp
-from 
-    #measurement_parent_concepts_of_interest mpci
-cross join
-    [Results].[deident_CURE_ID_person] p
+    dci.concept_id as drug_concept_id,
+    dci.concept_name as drug_concept_name,
+    CONCEPT.concept_id as ingredient_concept_id,
+    CONCEPT.concept_name as ingredient_name
+into 
+    #ingredients_of_interest
+from 
+    #drug_concepts_of_interest dci
 left join
-    [Results].[deident_CURE_ID_measurement] m 
-on
-    mpci.concept_id = m.measurement_concept_id 
-    and m.person_id = p.person_id
-group by 
-    p.person_id
-    ,mpci.ancestor_concept_id
-    ,mpci.concept_name
+    CONCEPT_ANCESTOR on
+        descendant_concept_id = dci.concept_id
+left join 
+    CONCEPT on CONCEPT.concept_id = ancestor_concept_id 
+where 
+    concept_class_id = 'Ingredient'
+;
+ 
 
- 
-
---This orders patients by how frequently the record occurs and does so for each individual concept
-DROP TABLE IF EXISTS #measurment_concept_count_rank;
-select  
-    concept_name,
-    concept_id,
-    concept_count,
-    row_number() over (partition by concept_id order by concept_count) as rownumber
-into
-    #measurment_concept_count_rank 
-from 
-    #measurement_count_temp
-
- 
-
---This summary table aims to show how many measurement records are present per patient. 
---Because the clinical course for patients varies considerably, some patients have very few records; others have many.
---The summary table has a row for each ancestor concept included in the measurement table
---For each measurement, each patient in the cohort is ranked according to how many records of the measurement are present during the defined visit
---The columns show how many measurement records are present per patient per measurement concept for the 25th percentile, median, 75th percentile, and 95th percentile of patients
-select 
-    concept_name, 
-    x1.concept_id, 
-    percentile_25, 
-    median,
-    percentile_75,
-    percentile_95,
-	CASE 
-	WHEN median = 0 
-		THEN 'For half of patients, there were no records of this measurement. 5% of patients had ' + 
-		CAST(percentile_95 AS VARCHAR(10)) + 
-		' or more records.'
-	ELSE 
-		'For half of patients, there were at least ' + 
-		CAST(median AS VARCHAR(10)) + 
-		' records. Most patients (25th-75th percentile) had '  +
-		CAST(percentile_25 AS VARCHAR(10)) + '-' + 
-		CAST(percentile_75 AS VARCHAR(10)) + 
-		' records. 5% of patients had ' + 
-		CAST(percentile_95 AS VARCHAR(10)) + 
-		' or more records.'
-   END AS interpretation
+--Create table of drug exposures by ingredient
+drop table if exists #drug_exposure_by_ingredient
+select
+    ingredient_name
+    ,ingredient_concept_id
+    ,d.drug_concept_id
+    ,person_id
+into 
+    #drug_exposure_by_ingredient
 from
-    (select distinct ancestor_concept_id as concept_id, concept_name from #measurement_parent_concepts_of_interest) x1
-full join 
-    (select concept_id, concept_count as percentile_25
-        FROM #measurment_concept_count_rank
-        where rownumber = floor(0.25 * (select count(person_id) from [Results].[deident_CURE_ID_person]))
-    ) as p25
-    on p25.concept_id = x1.concept_id
-full join 
-    (select concept_id, concept_count as median
-        FROM #measurment_concept_count_rank
-        where rownumber = floor(0.50 * (select count(person_id) from [Results].[deident_CURE_ID_person]))
-    ) as p50
-    on p50.concept_id =x1.concept_id
-full join 
-    (select concept_id, concept_count as percentile_75
-        FROM #measurment_concept_count_rank
-        where rownumber = floor(0.75 * (select count(person_id) from [Results].[deident_CURE_ID_person]))
-    ) as p75
-    on p75.concept_id = x1.concept_id
-full join 
-    (select concept_id, concept_count as percentile_95
-        FROM #measurment_concept_count_rank
-        where rownumber = floor(0.95 * (select count(person_id) from [Results].[deident_CURE_ID_person]))
-    ) as p95
-    on p95.concept_id =x1.concept_id
-order by median desc, 
-percentile_75 desc,
-percentile_95 desc
+    [Results].[deident_CURE_ID_drug_exposure] d
+left join 
+    #ingredients_of_interest i
+    on
+        i.drug_concept_id = d.drug_concept_id
+;
+ 
+
+--Ingredient use by person
+drop table if exists #ingredient_use_by_person
+select
+    ingredient_name
+    ,ingredient_concept_id
+    ,count(person_id) as person_count    
+    ,(100 * count(person_id) / 
+        (select count(distinct person_id) from #drug_exposure_by_ingredient)
+    ) as person_perc
+into #ingredient_use_by_person
+from
+        (select distinct 
+            person_id
+            ,ingredient_concept_id
+            ,ingredient_name
+        from 
+            #drug_exposure_by_ingredient) as x1
+group by 
+    ingredient_concept_id
+    ,ingredient_name
+order by
+    person_count desc
+;
+ 
+
+drop table if exists #ingredient_count_by_person
+select
+    ingredient_name
+    ,ingredient_concept_id
+    ,avg(ingredient_admin_count_per_person) as average_admin_per_person
+    ,max(ingredient_admin_count_per_person) as max_admin_per_person
+into #ingredient_count_by_person
+from
+    (select 
+        ingredient_name
+        ,ingredient_concept_id
+        ,person_id
+        ,count(ingredient_concept_id) as ingredient_admin_count_per_person
+    from #drug_exposure_by_ingredient
+    group by person_id, ingredient_concept_id, ingredient_name
+    ) as x1
+group by 
+    ingredient_concept_id
+    ,ingredient_name
+;
+ 
+
+--Display summary table for each drug ingredient:
+----the number of persons who took the drug ingredient
+----percent of persons who took the drug ingredient
+----average administrations of the drug ingredient per person who took the drug
+----maximum administrations of the drug ingredient per person
+select 
+    #ingredient_use_by_person.ingredient_name
+    ,#ingredient_use_by_person.ingredient_concept_id
+    ,#ingredient_use_by_person.person_count
+    ,#ingredient_use_by_person.person_perc
+    ,#ingredient_count_by_person.average_admin_per_person
+    ,#ingredient_count_by_person.max_admin_per_person
+from
+    #ingredient_use_by_person
+left join
+    #ingredient_count_by_person
+on
+    #ingredient_use_by_person.ingredient_concept_id = #ingredient_count_by_person.ingredient_concept_id
+order by person_count desc
+;
+
+--Match at the drug_concept_id for the cure_id drugs of interest
+drop table if exists #person_drug_category;
+select person_id, concept_id, drug_category, count(distinct drug_exposure_id) as n_drug_exposures
+into #person_drug_category
+from [Results].[deident_CURE_ID_drug_exposure] de
+    join [Results].[cure_id_drugs_of_interest] di on de.drug_concept_id = di.concept_id
+    group by person_id, concept_id, drug_category
+    order by person_id, drug_category
+;
+
+
+--This matches at the drug_concept_id which will miss drug_exposures coded at the ingredient level
+select * from (select drug_category, count(distinct person_id) as n
+               from #person_drug_category
+               group by drug_category
+               union
+               select distinct drug_category, 0
+               from [Results].[cure_id_drugs_of_interest]
+               where drug_category not in (select distinct drug_category from #person_drug_category)) t
+order by n desc
+;
+
+-- Testing the code
+-- with ingredient_drug_exposure as (
+--         select drug_exposure_id, person_id, c1.concept_id as ingredient_concept_id,
+--             c1.concept_name as ingredient_concept_name
+--         from [Results].[deident_CURE_ID_drug_exposure] cde
+--             join concept_ancestor ca on cde.drug_concept_id = ca.descendant_concept_id
+--             join concept c1 on c1.concept_id = ca.ancestor_concept_id and c1.concept_class_id = 'Ingredient'
+--     )
+-- select drug_exposure_id, person_id,
+--            string_agg(ingredient_concept_name, '|') within group ( order by ingredient_concept_name ) as ingredient_list
+--            from ingredient_drug_exposure group by drug_exposure_id, person_id
+-- ;
+
+
+--build an ingredient list for drugs in different categories
+drop table if exists #drug_categories_expanded_to_ingredients;
+with expanded_to_ingredients as (
+select distinct drug_category,
+                c2.concept_id as ingredient_concept_id,
+                c2.concept_name as ingredient_concept_name
+from [Results].[cure_id_drugs_of_interest] cid
+    join concept c1 on cid.concept_id = c1.concept_id
+    join concept_ancestor ca on ca.descendant_concept_id = cid.concept_id
+    join concept c2 on c2.concept_id = ca.ancestor_concept_id and c2.concept_class_id = 'Ingredient')
+select dei.*, n_ingredients
+    into #drug_categories_expanded_to_ingredients
+from expanded_to_ingredients dei join
+    (select drug_category, count(distinct ingredient_concept_id) as n_ingredients
+     from expanded_to_ingredients group by drug_category) ni
+        on ni.drug_category = dei.drug_category
+order by dei.drug_category, ingredient_concept_name
+;
+
+-- Groups at the drug_exposure_id level to find drugs with combination ingredients, e.g., Paxlovid (nirmatrelvir and ritonavir)
+drop table if exists #drug_exposure_id_ingredient_list;
+with drug_categories as (select drug_category,
+                                string_agg(ingredient_concept_name, '|') within group (order by ingredient_concept_name)
+                                    as ingredient_list
+                         from #drug_categories_expanded_to_ingredients
+                         group by drug_category),
+    ingredient_drug_exposure as (
+        select drug_exposure_id, person_id, c1.concept_id as ingredient_concept_id,
+            c1.concept_name as ingredient_concept_name
+        from [Results].[deident_CURE_ID_drug_exposure] cde
+            join concept_ancestor ca on cde.drug_concept_id = ca.descendant_concept_id
+            join concept c1 on c1.concept_id = ca.ancestor_concept_id and c1.concept_class_id = 'Ingredient'
+    )
+    select t.*, dc.drug_category
+    into #drug_exposure_id_ingredient_list
+    from (
+    select drug_exposure_id, person_id,
+           string_agg(ingredient_concept_name, '|') within group ( order by ingredient_concept_name ) as ingredient_list
+           from ingredient_drug_exposure group by drug_exposure_id, person_id) t
+    join drug_categories dc on dc.ingredient_list = t.ingredient_list
+;
+
+--Results for evaluating Cure ID drugs of interest
+with drug_category_count as (select count(distinct person_id) as n_with_drug, drug_category
+                             from (select distinct person_id, drug_category
+                                   from #drug_exposure_id_ingredient_list
+                                   group by person_id, drug_category
+                                   union
+                                   select distinct person_id, drug_category from #person_drug_category
+                                   ) t
+                             group by drug_category)
+select z.*, (cast(n_with_drug as float) / n_with_any_drug_exposure) * 100 as percent_with_drug_category from
+            (select *
+               from drug_category_count
+               union
+               select distinct 0, drug_category
+               from [Results].[cure_id_drugs_of_interest]
+               where drug_category
+                         not in (select distinct drug_category from drug_category_count)) z
+cross join (select count(distinct person_id) as n_with_any_drug_exposure from [Results].[deident_CURE_ID_drug_exposure]) zz
+order by n_with_drug desc
+;
+

--- a/Cohort curation scripts/07_C_drug_exposure_profile.sql
+++ b/Cohort curation scripts/07_C_drug_exposure_profile.sql
@@ -3,6 +3,298 @@
 -----------------------------------
  
 
+
+drop table if exists [Results].[cure_id_drugs_of_interest];
+create table [Results].[cure_id_drugs_of_interest] (drug_category varchar(255),
+                                                    concept_id int not null,
+                                                    drug_description varchar(512));
+
+insert into [Results].[cure_id_drugs_of_interest] (drug_category, concept_id, drug_description) values
+   ('nirmatrelvir and ritonavir', 780186, '{10 (nirmatrelvir 150 MG Oral Tablet) / 10 (ritonavir 100 MG Oral Tablet) } Pack [Paxlovid 150 MG /100 MG Dose Pack]'),
+   ('nirmatrelvir and ritonavir', 780185, '{10 (nirmatrelvir 150 MG Oral Tablet) / 10 (ritonavir 100 MG Oral Tablet) } Pack'),
+   ('nirmatrelvir and ritonavir', 702577, '{20 (nirmatrelvir 150 MG Oral Tablet) / 10 (ritonavir 100 MG Oral Tablet) } Pack'),
+   ('nirmatrelvir and ritonavir', 702578, '{20 (nirmatrelvir 150 MG Oral Tablet) / 10 (ritonavir 100 MG Oral Tablet) } Pack [Paxlovid 5-Day]'),
+   ('nirmatrelvir and ritonavir', 702530, 'nirmatrelvir'),
+   ('nirmatrelvir and ritonavir', 702531, 'nirmatrelvir 150 MG'),
+   ('nirmatrelvir and ritonavir', 702535, 'nirmatrelvir 150 MG Oral Tablet'),
+   ('nirmatrelvir and ritonavir', 702534, 'nirmatrelvir Oral Tablet'),
+   ('remdesivir', 37499272, 'remdesivir 100 MG'),
+   ('remdesivir', 36057819, 'remdesivir 100 MG Injectable Solution Box of 1'),
+   ('remdesivir', 36057825, 'remdesivir 100 MG Injectable Solution [Veklury]'),
+   ('remdesivir', 35896882, 'remdesivir 100 MG Injectable Solution [Veklury]'),
+   ('remdesivir', 35896880, 'remdesivir 100 MG Injectable Solution [Veklury] Box of 1'),
+   ('remdesivir', 36057823, 'remdesivir 100 MG Injectable Solution [Veklury] Box of 1'),
+   ('remdesivir', 36057811, 'remdesivir 100 MG Injection Box of 1'),
+   ('remdesivir', 37002796, 'remdesivir 100 MG Injection [Veklury]'),
+   ('remdesivir', 36057814, 'remdesivir 100 MG Injection [Veklury] Box of 1'),
+   ('remdesivir', 36074072, 'remdesivir 150 MG'),
+   ('remdesivir', 36057828, 'remdesivir 150 MG Injectable Solution Box of 1'),
+   ('remdesivir', 1145689, 'remdesivir 5 MG/ML'),
+   ('remdesivir', 36074073, 'remdesivir 5 MG/ML Injectable Solution Box of 1'),
+   ('remdesivir', 36074076, 'remdesivir 5 MG/ML Injectable Solution [Veklury]'),
+   ('remdesivir', 35896884, 'remdesivir 5 MG/ML Injectable Solution [Veklury]'),
+   ('remdesivir', 35896883, 'remdesivir 5 MG/ML Injectable Solution [Veklury] Box of 1'),
+   ('remdesivir', 36074075, 'remdesivir 5 MG/ML Injectable Solution [Veklury] Box of 1'),
+   ('remdesivir', 37002798, 'remdesivir 5 MG/ML Injection [Veklury]'),
+   ('remdesivir', 36057833, 'remdesivir Injectable Solution'),
+   ('remdesivir', 37499274, 'remdesivir Injection'),
+   ('Molnupiravir', 702536, 'molnupiravir'),
+   ('Molnupiravir', 702537, 'molnupiravir 200 MG'),
+   ('Molnupiravir', 779914, 'molnupiravir 200 MG [Lagevrio]'),
+   ('Molnupiravir', 702541, 'molnupiravir 200 MG Oral Capsule'),
+   ('Molnupiravir', 779918, 'molnupiravir 200 MG Oral Capsule [Lagevrio]'),
+   ('Molnupiravir', 702540, 'molnupiravir Oral Capsule'),
+   ('Molnupiravir', 779917, 'molnupiravir Oral Capsule [Lagevrio]'),
+   ('Molnupiravir', 702538, 'molnupiravir Oral Product'),
+   ('Molnupiravir', 702539, 'molnupiravir Pill'),
+   ('Favipiravir', 32765, 'Favipiravir'),
+   ('Favipiravir', 36061098, 'Favipiravir 200 MG'),
+   ('Favipiravir', 36061099, 'Favipiravir 200 MG [Avigan]'),
+   ('Favipiravir', 36061095, 'Favipiravir 200 MG Oral Tablet'),
+   ('Favipiravir', 36061097, 'Favipiravir 200 MG Oral Tablet [Avigan]'),
+   ('Favipiravir', 36061096, 'Favipiravir 200 MG Oral Tablet [Avigan] Box of 100'),
+   ('Favipiravir', 36061094, 'Favipiravir 200 MG Oral Tablet Box of 100'),
+   ('Favipiravir', 36061100, 'Favipiravir Oral Tablet'),
+   ('Favipiravir', 36061101, 'Favipiravir Oral Tablet [Avigan]'),
+   ('Lopinavir and ritonavir', 19048073, 'lopinavir 100 MG / ritonavir 25 MG [Kaletra]'),
+   ('Lopinavir and ritonavir', 1748985, 'lopinavir 100 MG / ritonavir 25 MG Oral Tablet'),
+   ('Lopinavir and ritonavir', 1748987, 'lopinavir 100 MG / ritonavir 25 MG Oral Tablet [Kaletra]'),
+   ('Lopinavir and ritonavir', 19048077, 'lopinavir 133 MG / ritonavir 33.3 MG [Kaletra]'),
+   ('Lopinavir and ritonavir', 1748955, 'lopinavir 133 MG / ritonavir 33.3 MG Oral Capsule'),
+   ('Lopinavir and ritonavir', 1748989, 'lopinavir 133 MG / ritonavir 33.3 MG Oral Capsule [Kaletra]'),
+   ('Lopinavir and ritonavir', 19048071, 'lopinavir 200 MG / ritonavir 50 MG [Kaletra]'),
+   ('Lopinavir and ritonavir', 19125242, 'lopinavir 200 MG / ritonavir 50 MG Oral Capsule'),
+   ('Lopinavir and ritonavir', 19122186, 'lopinavir 200 MG / ritonavir 50 MG Oral Tablet'),
+   ('Lopinavir and ritonavir', 1748986, 'lopinavir 200 MG / ritonavir 50 MG Oral Tablet [Kaletra]'),
+   ('Lopinavir and ritonavir', 19048075, 'lopinavir 80 MG/ML / ritonavir 20 MG/ML [Kaletra]'),
+   ('Lopinavir and ritonavir', 1748956, 'lopinavir 80 MG/ML / ritonavir 20 MG/ML Oral Solution'),
+   ('Lopinavir and ritonavir', 1748988, 'lopinavir 80 MG/ML / ritonavir 20 MG/ML Oral Solution [Kaletra]'),
+   ('Lopinavir and ritonavir', 40059335, 'lopinavir / ritonavir Oral Capsule'),
+   ('Lopinavir and ritonavir', 40160001, 'lopinavir / ritonavir Oral Capsule [Kaletra]'),
+   ('Lopinavir and ritonavir', 40059337, 'lopinavir / ritonavir Oral Solution'),
+   ('Lopinavir and ritonavir', 40160002, 'lopinavir / ritonavir Oral Solution [Kaletra]'),
+   ('Lopinavir and ritonavir', 40128015, 'lopinavir / ritonavir Oral Tablet'),
+   ('Lopinavir and ritonavir', 40160004, 'lopinavir / ritonavir Oral Tablet [Kaletra]'),
+   ('Ivermectin', 36232554, 'Stromectol Oral Product'),
+   ('Ivermectin', 36232555, 'Stromectol Pill'),
+   ('Ivermectin', 19085038, 'ivermectin 3 MG'),
+   ('Ivermectin', 36227067, 'ivermectin Oral Product'),
+   ('Ivermectin', 36227069, 'ivermectin Pill'),
+   ('Ivermectin', 19081725, 'ivermectin 3 MG [Stromectol]'),
+   ('Ivermectin', 40053195, 'ivermectin Oral Tablet [Stromectol]'),
+   ('Ivermectin', 40053194, 'ivermectin Oral Tablet'),
+   ('Hydroxychloroquine', 1777087, 'hydroxychloroquine'),
+   ('Hydroxychloroquine', 40051595, 'hydroxychloroquine Oral Tablet'),
+   ('Hydroxychloroquine', 40051596, 'hydroxychloroquine Oral Tablet [Plaquenil]'),
+   ('Hydroxychloroquine', 40184083, 'hydroxychloroquine sulfate 200 MG'),
+   ('Hydroxychloroquine', 40184084, 'hydroxychloroquine sulfate 200 MG Oral Tablet'),
+   ('Hydroxychloroquine', 40184085, 'hydroxychloroquine sulfate 200 MG Oral Tablet [Plaquenil]'),
+   ('Hydroxychloroquine', 40184087, 'hydroxychloroquine sulfate 200 MG [Plaquenil]'),
+   ('Hydroxychloroquine', 40051597, 'hydroxychloroquine Oral Tablet [Quineprox]'),
+   ('Hydroxychloroquine', 701777, 'hydroxychloroquine sulfate 100 MG'),
+   ('Hydroxychloroquine', 701778, 'hydroxychloroquine sulfate 100 MG Oral Tablet'),
+   ('Hydroxychloroquine', 40184086, 'hydroxychloroquine sulfate 200 MG Oral Tablet [Quineprox]'),
+   ('Hydroxychloroquine', 40184088, 'hydroxychloroquine sulfate 200 MG [Quineprox]'),
+   ('Hydroxychloroquine', 701779, 'hydroxychloroquine sulfate 300 MG'),
+   ('Hydroxychloroquine', 701780, 'hydroxychloroquine sulfate 300 MG Oral Tablet'),
+   ('Hydroxychloroquine', 40242199, 'hydroxychloroquine sulfate 400 MG'),
+   ('Hydroxychloroquine', 40242200, 'hydroxychloroquine sulfate 400 MG Oral Tablet'),
+   ('Dexamethasone', 1518254, 'dexamethasone'),
+   ('Dexamethasone', 40028260, 'dexamethasone Injectable Solution'),
+   ('Dexamethasone', 40241503, 'dexamethasone phosphate 4 MG/ML'),
+   ('Dexamethasone', 40241504, 'dexamethasone phosphate 4 MG/ML Injectable Solution'),
+   ('Dexamethasone', 40028601, 'dexamethasone Oral Tablet'),
+   ('Dexamethasone', 40028602, 'dexamethasone Oral Tablet [Decadron]'),
+   ('Dexamethasone', 1518608, 'dexamethasone 4 MG'),
+   ('Dexamethasone', 19117916, 'dexamethasone 4 MG [Decadron]'),
+   ('Dexamethasone', 1518292, 'dexamethasone 4 MG Oral Tablet'),
+   ('Dexamethasone', 19030003, 'dexamethasone 4 MG Oral Tablet [Decadron]'),
+   ('Dexamethasone', 1518607, 'dexamethasone 1.5 MG'),
+   ('Dexamethasone', 19117914, 'dexamethasone 1.5 MG [Decadron]'),
+   ('Dexamethasone', 19018906, 'dexamethasone 1.5 MG Oral Tablet'),
+   ('Dexamethasone', 19030001, 'dexamethasone 1.5 MG Oral Tablet [Decadron]'),
+   ('Dexamethasone', 1518609, 'dexamethasone 6 MG'),
+   ('Dexamethasone', 19117921, 'dexamethasone 6 MG [Decadron]'),
+   ('Dexamethasone', 1518293, 'dexamethasone 6 MG Oral Tablet'),
+   ('Dexamethasone', 19030008, 'dexamethasone 6 MG Oral Tablet [Decadron]'),
+   ('Dexamethasone', 1518606, 'dexamethasone 1 MG'),
+   ('Dexamethasone', 1518259, 'dexamethasone 1 MG Oral Tablet'),
+   ('Dexamethasone', 1719011, 'dexamethasone phosphate 10 MG/ML'),
+   ('Dexamethasone', 19076145, 'dexamethasone phosphate 10 MG/ML Injectable Solution'),
+   ('Dexamethasone', 1518603, 'dexamethasone 0.1 MG/ML'),
+   ('Dexamethasone', 19088972, 'dexamethasone 0.1 MG/ML [Decadron]'),
+   ('Dexamethasone', 19076136, 'dexamethasone 0.1 MG/ML Oral Solution'),
+   ('Dexamethasone', 1518851, 'dexamethasone 0.1 MG/ML Oral Solution [Decadron]'),
+   ('Dexamethasone', 40028599, 'dexamethasone Oral Solution'),
+   ('Dexamethasone', 40146415, 'dexamethasone Oral Solution [Decadron]'),
+   ('Baricitinib', 1510627, 'baricitinib'),
+   ('Baricitinib', 37497352, 'baricitinib 1 MG'),
+   ('Baricitinib', 37497354, 'baricitinib 1 MG [Olumiant]'),
+   ('Baricitinib', 37497353, 'baricitinib 1 MG Oral Tablet'),
+   ('Baricitinib', 37497355, 'baricitinib 1 MG Oral Tablet [Olumiant]'),
+   ('Baricitinib', 1510628, 'baricitinib 2 MG'),
+   ('Baricitinib', 1510634, 'baricitinib 2 MG [Olumiant]'),
+   ('Baricitinib', 1510632, 'baricitinib 2 MG Oral Tablet'),
+   ('Baricitinib', 1510638, 'baricitinib 2 MG Oral Tablet [Olumiant]'),
+   ('Baricitinib', 1758612, 'baricitinib 4 MG'),
+   ('Baricitinib', 779706, 'baricitinib 4 MG [Olumiant]'),
+   ('Baricitinib', 1758613, 'baricitinib 4 MG Oral Tablet'),
+   ('Baricitinib', 779707, 'baricitinib 4 MG Oral Tablet [Olumiant]'),
+   ('Baricitinib', 1510631, 'baricitinib Oral Tablet'),
+   ('Baricitinib', 1510635, 'baricitinib Oral Tablet [Olumiant]'),
+   ('Tocilizumab', 1356447, '0.9 ML tocilizumab 180 MG/ML Auto-Injector'),
+   ('Tocilizumab', 1356448, '0.9 ML tocilizumab 180 MG/ML Auto-Injector [Actemra]'),
+   ('Tocilizumab', 44507566, '0.9 ML tocilizumab 180 MG/ML Prefilled Syringe'),
+   ('Tocilizumab', 44507562, '0.9 ML tocilizumab 180 MG/ML Prefilled Syringe [Actemra]'),
+   ('Tocilizumab', 46275121, '10 ML tocilizumab 20 MG/ML Injection'),
+   ('Tocilizumab', 46275122, '10 ML tocilizumab 20 MG/ML Injection [Actemra]'),
+   ('Tocilizumab', 46275123, '20 ML tocilizumab 20 MG/ML Injection'),
+   ('Tocilizumab', 46275124, '20 ML tocilizumab 20 MG/ML Injection [Actemra]'),
+   ('Tocilizumab', 46275116, '4 ML tocilizumab 20 MG/ML Injection'),
+   ('Tocilizumab', 46275118, '4 ML tocilizumab 20 MG/ML Injection [Actemra]'),
+   ('Tocilizumab', 40171288, 'tocilizumab'),
+   ('Tocilizumab', 44507701, 'tocilizumab 180 MG/ML'),
+   ('Tocilizumab', 44507704, 'tocilizumab 180 MG/ML [Actemra]'),
+   ('Tocilizumab', 1355866, 'tocilizumab 180 MG/ML Auto-Injector'),
+   ('Tocilizumab', 1355867, 'tocilizumab 180 MG/ML Auto-Injector [Actemra]'),
+   ('Tocilizumab', 44507702, 'tocilizumab 180 MG/ML Prefilled Syringe'),
+   ('Tocilizumab', 44507703, 'tocilizumab 180 MG/ML Prefilled Syringe [Actemra]'),
+   ('Tocilizumab', 40171289, 'tocilizumab 20 MG/ML'),
+   ('Tocilizumab', 40171292, 'tocilizumab 20 MG/ML [Actemra]'),
+   ('Tocilizumab', 46275119, 'tocilizumab 20 MG/ML Injection'),
+   ('Tocilizumab', 46275120, 'tocilizumab 20 MG/ML Injection [Actemra]'),
+   ('Tocilizumab', 1355864, 'tocilizumab Auto-Injector'),
+   ('Tocilizumab', 1355865, 'tocilizumab Auto-Injector [Actemra]'),
+   ('Tocilizumab', 46275115, 'tocilizumab Injection'),
+   ('Tocilizumab', 46275117, 'tocilizumab Injection [Actemra]'),
+   ('Tocilizumab', 44507705, 'tocilizumab Prefilled Syringe'),
+   ('Tocilizumab', 44507706, 'tocilizumab Prefilled Syringe [Actemra]'),
+   ('Colchicine', 1101554, 'colchicine'),
+   ('Colchicine', 1101586, 'colchicine 0.6 MG'),
+   ('Colchicine', 40164493, 'colchicine 0.6 MG [Colcrys]'),
+   ('Colchicine', 1101556, 'colchicine 0.6 MG Oral Tablet'),
+   ('Colchicine', 40164492, 'colchicine 0.6 MG Oral Tablet [Colcrys]'),
+   ('Colchicine', 40031428, 'colchicine Oral Tablet'),
+   ('Colchicine', 40164494, 'colchicine Oral Tablet [Colcrys]'),
+   ('Colchicine', 1101560, 'allopurinol 100 MG / colchicine 0.5 MG Oral Tablet'),
+   ('Colchicine', 19061795, 'allopurinol 300 MG / colchicine 0.5 MG Extended Release Oral Capsule'),
+   ('Colchicine', 40005863, 'allopurinol / colchicine Extended Release Oral Capsule'),
+   ('Colchicine', 40005864, 'allopurinol / colchicine Oral Tablet'),
+   ('Colchicine', 1101588, 'colchicine 0.001 MG/MG'),
+   ('Colchicine', 19060123, 'colchicine 0.001 MG/MG / podophyllin 0.02 MG/MG Topical Ointment'),
+   ('Colchicine', 1366576, 'colchicine 0.12 MG/ML'),
+   ('Colchicine', 1361345, 'colchicine 0.12 MG/ML [Gloperba]'),
+   ('Colchicine', 1366579, 'colchicine 0.12 MG/ML Oral Solution'),
+   ('Colchicine', 1361349, 'colchicine 0.12 MG/ML Oral Solution [Gloperba]'),
+   ('Colchicine', 19099374, 'colchicine 0.25 MG'),
+   ('Colchicine', 19002015, 'colchicine 0.25 MG Oral Tablet'),
+   ('Colchicine', 19109346, 'colchicine 0.432 MG'),
+   ('Colchicine', 19108528, 'colchicine 0.432 MG Oral Tablet'),
+   ('Colchicine', 1101585, 'colchicine 0.54 MG'),
+   ('Colchicine', 19075823, 'colchicine 0.54 MG Oral Tablet'),
+   ('Colchicine', 1101583, 'colchicine 0.5 MG'),
+   ('Colchicine', 1101584, 'colchicine 0.5 MG/ML'),
+   ('Colchicine', 1101557, 'colchicine 0.5 MG/ML Injectable Solution'),
+   ('Colchicine', 19018901, 'colchicine 0.5 MG Oral Tablet'),
+   ('Colchicine', 1151424, 'colchicine 0.5 MG / probenecid 500 MG Oral Tablet'),
+   ('Colchicine', 1101587, 'colchicine 0.65 MG'),
+   ('Colchicine', 19075824, 'colchicine 0.65 MG Oral Tablet'),
+   ('Colchicine', 45776979, 'colchicine 0.6 MG [Mitigare]'),
+   ('Colchicine', 45776977, 'colchicine 0.6 MG Oral Capsule'),
+   ('Colchicine', 45776981, 'colchicine 0.6 MG Oral Capsule [Mitigare]'),
+   ('Colchicine', 1101589, 'colchicine 1 MG'),
+   ('Colchicine', 1101558, 'colchicine 1 MG Oral Tablet'),
+   ('Colchicine', 40031427, 'colchicine Injectable Solution'),
+   ('Colchicine', 45776976, 'colchicine Oral Capsule'),
+   ('Colchicine', 45776980, 'colchicine Oral Capsule [Mitigare]'),
+   ('Colchicine', 1366578, 'colchicine Oral Solution'),
+   ('Colchicine', 1361346, 'colchicine Oral Solution [Gloperba]'),
+   ('Colchicine', 40031406, 'colchicine / podophyllin Topical Ointment'),
+   ('Azithromycin', 1734104, 'azithromycin'),
+   ('Azithromycin', 40013068, 'azithromycin Oral Tablet'),
+   ('Azithromycin', 40013069, 'azithromycin Oral Tablet [Zithromax]'),
+   ('Azithromycin', 19128020, '{6 (azithromycin 250 MG Oral Tablet) } Pack'),
+   ('Azithromycin', 19128124, '{6 (azithromycin 250 MG Oral Tablet [Zithromax]) } Pack [Z-PAK]'),
+   ('Azithromycin', 1734140, 'azithromycin 250 MG'),
+   ('Azithromycin', 19073777, 'azithromycin 250 MG Oral Tablet'),
+   ('Azithromycin', 1734132, 'azithromycin 250 MG Oral Tablet [Zithromax]'),
+   ('Azithromycin', 19116114, 'azithromycin 250 MG [Zithromax]'),
+   ('Azithromycin', 19128018, '{3 (azithromycin 500 MG Oral Tablet) } Pack'),
+   ('Azithromycin', 19128131, '{3 (azithromycin 500 MG Oral Tablet [Zithromax]) } Pack [TRI-PAK]'),
+   ('Azithromycin', 19085757, 'azithromycin 500 MG'),
+   ('Azithromycin', 1734134, 'azithromycin 500 MG Oral Tablet'),
+   ('Azithromycin', 1734133, 'azithromycin 500 MG Oral Tablet [Zithromax]'),
+   ('Azithromycin', 19120522, 'azithromycin 500 MG [Zithromax]'),
+   ('Azithromycin', 19133860, '{3 (azithromycin 250 MG Oral Tablet) } Pack'),
+   ('Azithromycin', 19133861, '{3 (azithromycin 250 MG Oral Tablet [Zithromax]) } Pack [Z-Pak Sample]'),
+   ('Azithromycin', 19128019, '{6 (azithromycin 250 MG Oral Capsule) } Pack'),
+   ('Azithromycin', 19108236, 'azithromycin 1000 MG'),
+   ('Azithromycin', 19106272, 'azithromycin 1000 MG Oral Tablet'),
+   ('Azithromycin', 40164101, 'azithromycin 1000 MG Powder for Oral Suspension'),
+   ('Azithromycin', 40164102, 'azithromycin 1000 MG Powder for Oral Suspension [Zithromax]'),
+   ('Azithromycin', 40221346, 'azithromycin 1000 MG [Zithromax]'),
+   ('Azithromycin', 19126614, 'azithromycin 10 MG/ML'),
+   ('Azithromycin', 19126616, 'azithromycin 10 MG/ML [AzaSite]'),
+   ('Azithromycin', 19126615, 'azithromycin 10 MG/ML Ophthalmic Solution'),
+   ('Azithromycin', 19126617, 'azithromycin 10 MG/ML Ophthalmic Solution [AzaSite]'),
+   ('Azithromycin', 19128200, 'azithromycin 10 MG/ML Ophthalmic Suspension'),
+   ('Azithromycin', 1734139, 'azithromycin 20 MG/ML'),
+   ('Azithromycin', 19073776, 'azithromycin 20 MG/ML Oral Suspension'),
+   ('Azithromycin', 19046028, 'azithromycin 20 MG/ML Oral Suspension [Zithromax]'),
+   ('Azithromycin', 19038753, 'azithromycin 20 MG/ML [Zithromax]'),
+   ('Azithromycin', 19123885, 'azithromycin 250 MG [Azinthromycin]'),
+   ('Azithromycin', 1734107, 'azithromycin 250 MG Oral Capsule'),
+   ('Azithromycin', 19006685, 'azithromycin 250 MG Oral Capsule [Zithromax]'),
+   ('Azithromycin', 19123886, 'azithromycin 250 MG Oral Tablet [Azinthromycin]'),
+   ('Azithromycin', 19113148, 'azithromycin 250 MG Oral Tablet [ZPAK]'),
+   ('Azithromycin', 19113147, 'azithromycin 250 MG [ZPAK]'),
+   ('Azithromycin', 1734167, 'azithromycin 33.3 MG/ML'),
+   ('Azithromycin', 1734168, 'azithromycin 33.3 MG/ML Extended Release Suspension'),
+   ('Azithromycin', 1734169, 'azithromycin 33.3 MG/ML Extended Release Suspension [Zmax]'),
+   ('Azithromycin', 19121228, 'azithromycin 33.3 MG/ML Oral Suspension'),
+   ('Azithromycin', 19122010, 'azithromycin 33.3 MG/ML [Zmax]'),
+   ('Azithromycin', 19080954, 'azithromycin 40 MG/ML'),
+   ('Azithromycin', 1734108, 'azithromycin 40 MG/ML Oral Suspension'),
+   ('Azithromycin', 19006686, 'azithromycin 40 MG/ML Oral Suspension [Zithromax]'),
+   ('Azithromycin', 19116115, 'azithromycin 40 MG/ML [Zithromax]'),
+   ('Azithromycin', 35603389, 'azithromycin 500 MG Injection'),
+   ('Azithromycin', 35603391, 'azithromycin 500 MG Injection [Zithromax]'),
+   ('Azithromycin', 19108237, 'azithromycin 50 MG'),
+   ('Bebtelovimab', 1759259, '2 ML bebtelovimab 87.5 MG/ML Injection'),
+   ('Bebtelovimab', 1759073, 'bebtelovimab'),
+   ('Bebtelovimab', 1759074, 'bebtelovimab 87.5 MG/ML'),
+   ('Bebtelovimab', 1759077, 'bebtelovimab 87.5 MG/ML Injection'),
+   ('Bebtelovimab', 1759076, 'bebtelovimab Injection'),
+   ('Tixagevimab and cilgavimab', 702575, '{1 (1.5 ML cilgavimab 100 MG/ML Injection) / 1 (1.5 ML tixagevimab 100 MG/ML Injection) } Pack'),
+   ('Tixagevimab and cilgavimab', 702576, '{1 (1.5 ML cilgavimab 100 MG/ML Injection) / 1 (1.5 ML tixagevimab 100 MG/ML Injection) } Pack [Evusheld 2 vial carton]'),
+   ('Tixagevimab and cilgavimab', 702580, '1.5 ML tixagevimab 100 MG/ML Injection'),
+   ('Tixagevimab and cilgavimab', 702418, 'tixagevimab'),
+   ('Tixagevimab and cilgavimab', 702419, 'tixagevimab 100 MG/ML'),
+   ('Tixagevimab and cilgavimab', 702422, 'tixagevimab 100 MG/ML Injection'),
+   ('Tixagevimab and cilgavimab', 702421, 'tixagevimab Injection'),
+   ('Tixagevimab and cilgavimab', 702649, '1.5 ML cilgavimab 100 MG/ML Injection'),
+   ('Tixagevimab and cilgavimab', 702423, 'cilgavimab'),
+   ('Tixagevimab and cilgavimab', 702424, 'cilgavimab 100 MG/ML'),
+   ('Tixagevimab and cilgavimab', 702427, 'cilgavimab 100 MG/ML Injection'),
+   ('Tixagevimab and cilgavimab', 702425, 'cilgavimab Injectable Product'),
+   ('Tixagevimab and cilgavimab', 702426, 'cilgavimab Injection'),
+   ('Sotrovimab', 1537593, '8 ML sotrovimab 62.5 MG/ML Injection'),
+   ('Sotrovimab', 1536976, 'sotrovimab'),
+   ('Sotrovimab', 1536986, 'sotrovimab 62.5 MG/ML'),
+   ('Sotrovimab', 1536989, 'sotrovimab 62.5 MG/ML Injection'),
+   ('Sotrovimab', 1536988, 'sotrovimab Injection'),
+   ('Anakinra', 1114379, '0.67 ML anakinra 149 MG/ML Prefilled Syringe'),
+   ('Anakinra', 1114380, '0.67 ML anakinra 149 MG/ML Prefilled Syringe [Kineret]'),
+   ('Anakinra', 1114375, 'anakinra'),
+   ('Anakinra', 19127200, 'anakinra 149 MG/ML'),
+   ('Anakinra', 19033445, 'anakinra 149 MG/ML [Kineret]'),
+   ('Anakinra', 42902611, 'anakinra 149 MG/ML Prefilled Syringe'),
+   ('Anakinra', 42902489, 'anakinra 149 MG/ML Prefilled Syringe [Kineret]'),
+   ('Anakinra', 40141482, 'anakinra Prefilled Syringe'),
+   ('Anakinra', 40141483, 'anakinra Prefilled Syringe [Kineret]')
+;
+
+
 --Create table of all drugs given in the cohort
 DROP TABLE IF EXISTS #drug_concepts_of_interest;
 select distinct
@@ -16,7 +308,7 @@ FROM
         CONCEPT 
     on
         concept_id = drug_concept_id
-
+;
  
 
 ---Roll up drugs into ingredients
@@ -37,7 +329,7 @@ left join 
     CONCEPT on CONCEPT.concept_id = ancestor_concept_id 
 where 
     concept_class_id = 'Ingredient'
-
+;
  
 
 --Create table of drug exposures by ingredient
@@ -55,7 +347,7 @@ left join 
     #ingredients_of_interest i
     on
         i.drug_concept_id = d.drug_concept_id
-
+;
  
 
 --Ingredient use by person
@@ -80,7 +372,7 @@ group by 
     ,ingredient_name
 order by
     person_count desc
-
+;
  
 
 drop table if exists #ingredient_count_by_person
@@ -102,7 +394,7 @@ from
 group by 
     ingredient_concept_id
     ,ingredient_name
-
+;
  
 
 --Display summary table for each drug ingredient:
@@ -124,3 +416,104 @@ left join
 on
     #ingredient_use_by_person.ingredient_concept_id = #ingredient_count_by_person.ingredient_concept_id
 order by person_count desc
+;
+
+--Match at the drug_concept_id for the cure_id drugs of interest
+drop table if exists #person_drug_category;
+select person_id, concept_id, drug_category, count(distinct drug_exposure_id) as n_drug_exposures
+into #person_drug_category
+from [Results].[deident_CURE_ID_drug_exposure] de
+    join [Results].[cure_id_drugs_of_interest] di on de.drug_concept_id = di.concept_id
+    group by person_id, concept_id, drug_category
+    order by person_id, drug_category
+;
+
+
+--This matches at the drug_concept_id which will miss drug_exposures coded at the ingredient level
+select * from (select drug_category, count(distinct person_id) as n
+               from #person_drug_category
+               group by drug_category
+               union
+               select distinct drug_category, 0
+               from [Results].[cure_id_drugs_of_interest]
+               where drug_category not in (select distinct drug_category from #person_drug_category)) t
+order by n desc
+;
+
+-- Testing the code
+-- with ingredient_drug_exposure as (
+--         select drug_exposure_id, person_id, c1.concept_id as ingredient_concept_id,
+--             c1.concept_name as ingredient_concept_name
+--         from [Results].[deident_CURE_ID_drug_exposure] cde
+--             join concept_ancestor ca on cde.drug_concept_id = ca.descendant_concept_id
+--             join concept c1 on c1.concept_id = ca.ancestor_concept_id and c1.concept_class_id = 'Ingredient'
+--     )
+-- select drug_exposure_id, person_id,
+--            string_agg(ingredient_concept_name, '|') within group ( order by ingredient_concept_name ) as ingredient_list
+--            from ingredient_drug_exposure group by drug_exposure_id, person_id
+-- ;
+
+
+--build an ingredient list for drugs in different categories
+drop table if exists #drug_categories_expanded_to_ingredients;
+with expanded_to_ingredients as (
+select distinct drug_category,
+                c2.concept_id as ingredient_concept_id,
+                c2.concept_name as ingredient_concept_name
+from [Results].[cure_id_drugs_of_interest] cid
+    join concept c1 on cid.concept_id = c1.concept_id
+    join concept_ancestor ca on ca.descendant_concept_id = cid.concept_id
+    join concept c2 on c2.concept_id = ca.ancestor_concept_id and c2.concept_class_id = 'Ingredient')
+select dei.*, n_ingredients
+    into #drug_categories_expanded_to_ingredients
+from expanded_to_ingredients dei join
+    (select drug_category, count(distinct ingredient_concept_id) as n_ingredients
+     from expanded_to_ingredients group by drug_category) ni
+        on ni.drug_category = dei.drug_category
+order by dei.drug_category, ingredient_concept_name
+;
+
+-- Groups at the drug_exposure_id level to find drugs with combination ingredients, e.g., Paxlovid (nirmatrelvir and ritonavir)
+drop table if exists #drug_exposure_id_ingredient_list;
+with drug_categories as (select drug_category,
+                                string_agg(ingredient_concept_name, '|') within group (order by ingredient_concept_name)
+                                    as ingredient_list
+                         from #drug_categories_expanded_to_ingredients
+                         group by drug_category),
+    ingredient_drug_exposure as (
+        select drug_exposure_id, person_id, c1.concept_id as ingredient_concept_id,
+            c1.concept_name as ingredient_concept_name
+        from [Results].[deident_CURE_ID_drug_exposure] cde
+            join concept_ancestor ca on cde.drug_concept_id = ca.descendant_concept_id
+            join concept c1 on c1.concept_id = ca.ancestor_concept_id and c1.concept_class_id = 'Ingredient'
+    )
+    select t.*, dc.drug_category
+    into #drug_exposure_id_ingredient_list
+    from (
+    select drug_exposure_id, person_id,
+           string_agg(ingredient_concept_name, '|') within group ( order by ingredient_concept_name ) as ingredient_list
+           from ingredient_drug_exposure group by drug_exposure_id, person_id) t
+    join drug_categories dc on dc.ingredient_list = t.ingredient_list
+;
+
+--Results for evaluating Cure ID drugs of interest
+with drug_category_count as (select count(distinct person_id) as n_with_drug, drug_category
+                             from (select distinct person_id, drug_category
+                                   from #drug_exposure_id_ingredient_list
+                                   group by person_id, drug_category
+                                   union
+                                   select distinct person_id, drug_category from #person_drug_category
+                                   ) t
+                             group by drug_category)
+select z.*, (cast(n_with_drug as float) / n_with_any_drug_exposure) * 100 as percent_with_drug_category from
+            (select *
+               from drug_category_count
+               union
+               select distinct 0, drug_category
+               from [Results].[cure_id_drugs_of_interest]
+               where drug_category
+                         not in (select distinct drug_category from drug_category_count)) z
+cross join (select count(distinct person_id) as n_with_any_drug_exposure from [Results].[deident_CURE_ID_drug_exposure]) zz
+order by n_with_drug desc
+;
+

--- a/Cohort curation scripts/07_F_observation_profile.sql
+++ b/Cohort curation scripts/07_F_observation_profile.sql
@@ -1,0 +1,11 @@
+/******* OBSERVATION *******/
+  SELECT
+  observation_concept_id,
+  c.concept_name,
+  COUNT(distinct person_id) as [Num People],
+  COUNT(*) as [Num Records]
+  from [Results].[deident_CURE_ID_observation] o
+  left outer join concept c on o.observation_concept_id = c.concept_id
+  group by observation_concept_id, c.concept_name
+  order by COUNT(distinct person_id) as [Num People]
+;


### PR DESCRIPTION
Added code for updated concepts which merge code lists, add Charlson's DX, mapped Z codes, and LOINC classification codes which do not have a descendent in `concept_ancestor`, but a descendent can be found using `concept_relationship`, and codes for payer types.

Also, included updates to measurement and drug profiles which were written earlier.

Added a simple SQL file for profiling the observation_table